### PR TITLE
fix: skip unread books before Hardcover lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Unread Book Filtering Before Hardcover Lookup**: Skip unstarted books (when `process_unread_books` is disabled) before matching the book in Hardcover, instead of after. This prevents unnecessary Hardcover API requests and mismatch records for books that were going to be skipped anyway.
+- **Sync Summary Accuracy**: Books skipped by the unread filter are no longer counted in `BooksSynced` (they still count toward total books processed).
+
 ## [v3.3.1] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Unread Book Filtering Before Hardcover Lookup**: Skip unstarted books (when `process_unread_books` is disabled) before matching the book in Hardcover, instead of after. This prevents unnecessary Hardcover API requests and mismatch records for books that were going to be skipped anyway.
 - **Sync Summary Accuracy**: Books skipped by the unread filter are no longer counted in `BooksSynced` (they still count toward total books processed).
+- Thanks to @matthewbrahms for this contribution.
 
 ## [v3.3.1] - 2026-07-01
 

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -1072,6 +1072,7 @@ func (s *Service) processBook(ctx context.Context, book models.AudiobookshelfBoo
 	if book.Progress.CurrentTime <= 0 && !s.config.Sync.ProcessUnreadBooks && !book.Progress.IsFinished {
 		bookLog.Debug("Skipping unstarted book before Hardcover lookup", map[string]interface{}{
 			"current_time": book.Progress.CurrentTime,
+			"book_id":      book.ID,
 		})
 		bookProcessed = false // Explicitly mark as not processed when skipping unread books
 		return nil

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -1030,7 +1030,7 @@ func (s *Service) processBook(ctx context.Context, book models.AudiobookshelfBoo
 	}()
 
 	bookLog.Debug("Starting book processing")
-	// Mark as processed by default, will be set to false if there's an error
+	// Mark as processed by default; set to false when the book is skipped or fails
 	bookProcessed = true
 
 	// Media type filtering: skip ebooks unless explicitly enabled
@@ -1062,6 +1062,19 @@ func (s *Service) processBook(ctx context.Context, book models.AudiobookshelfBoo
 			"filter":  s.config.Sync.TestBookFilter,
 			"dry_run": s.config.Sync.DryRun,
 		})
+	}
+
+	// Skip books that haven't been started unless ProcessUnreadBooks is true.
+	// This must happen before any Hardcover lookup so that a broad library pass
+	// doesn't spend API capacity (or create mismatch records) on books this
+	// profile has opted out of processing.
+	// Don't skip finished books even if CurrentTime is 0 (they have progress=1.0).
+	if book.Progress.CurrentTime <= 0 && !s.config.Sync.ProcessUnreadBooks && !book.Progress.IsFinished {
+		bookLog.Debug("Skipping unstarted book before Hardcover lookup", map[string]interface{}{
+			"current_time": book.Progress.CurrentTime,
+		})
+		bookProcessed = false // Explicitly mark as not processed when skipping unread books
+		return nil
 	}
 
 	// Early filtering for incremental sync - check if book needs syncing
@@ -1401,24 +1414,6 @@ func (s *Service) processBook(ctx context.Context, book models.AudiobookshelfBoo
 	})
 
 	bookLog.Debug("Calculated book progress", nil)
-
-	// Skip books that haven't been started unless ProcessUnreadBooks is true
-	// This check is done after progress enhancement to ensure we have accurate progress data
-	bookLog.Debug("Checking ProcessUnreadBooks setting", map[string]interface{}{
-		"current_time":          book.Progress.CurrentTime,
-		"process_unread_books":  s.config.Sync.ProcessUnreadBooks,
-		"book_id":               book.ID,
-		"title":                 book.Media.Metadata.Title,
-	})
-	
-	// Don't skip finished books even if CurrentTime is 0 (they have progress=1.0)
-	if book.Progress.CurrentTime <= 0 && !s.config.Sync.ProcessUnreadBooks && !book.Progress.IsFinished {
-		bookLog.Debug("Skipping unstarted book (ProcessUnreadBooks is false)", map[string]interface{}{
-			"current_time": book.Progress.CurrentTime,
-		})
-		bookProcessed = true // Count as processed since we made a decision to skip
-		return nil
-	}
 
 	// Skip books below minimum progress threshold
 	if progress < s.config.Sync.MinimumProgress && progress > 0 {

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -710,6 +710,7 @@ func createTestService() (*Service, *MockHardcoverClient) {
 		config:    cfg,
 		log:       logger.Get(),
 		state:     state,
+		summary:             &SyncSummary{},
 		lastProgressUpdates: make(map[string]progressUpdateInfo),
 		asinCache:           make(map[string]*models.HardcoverBook),
 		persistentCache:     persistentCache,
@@ -718,6 +719,130 @@ func createTestService() (*Service, *MockHardcoverClient) {
 	}
 
 	return svc, mockClient
+}
+
+func TestProcessBookSkipsUnreadBeforeHardcoverLookup(t *testing.T) {
+	svc, mockClient := createTestService()
+	svc.config.Sync.Incremental = false
+	svc.config.Sync.ProcessUnreadBooks = false
+
+	book := toAudiobookshelfBook(createTestBook("unread-book", "Unread Book", "Test Author", "ASIN", "ISBN"))
+	book.Progress.CurrentTime = 0
+	book.Progress.IsFinished = false
+
+	err := svc.processBook(context.Background(), *book, &models.AudiobookshelfUserProgress{})
+
+	assert.NoError(t, err)
+	mockClient.AssertNotCalled(t, "SearchBookByASIN", mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "SearchBookByISBN13", mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "SearchBookByISBN10", mock.Anything, mock.Anything)
+	assert.Equal(t, int32(0), svc.summary.BooksSynced, "skipped unread book must not count as synced")
+	assert.Equal(t, int32(1), svc.summary.TotalBooksProcessed)
+}
+
+// addMediaProgress appends a mediaProgress entry to a user progress fixture.
+// It exists so tests don't each restate the anonymous struct element type of
+// models.AudiobookshelfUserProgress.MediaProgress.
+func addMediaProgress(up *models.AudiobookshelfUserProgress, libraryItemID string, currentTime float64, startedAt, lastUpdate int64) {
+	up.MediaProgress = append(up.MediaProgress, struct {
+		ID            string  `json:"id"`
+		LibraryItemID string  `json:"libraryItemId"`
+		UserID        string  `json:"userId"`
+		IsFinished    bool    `json:"isFinished"`
+		Progress      float64 `json:"progress"`
+		CurrentTime   float64 `json:"currentTime"`
+		Duration      float64 `json:"duration"`
+		StartedAt     int64   `json:"startedAt"`
+		FinishedAt    int64   `json:"finishedAt"`
+		LastUpdate    int64   `json:"lastUpdate"`
+		TimeListening float64 `json:"timeListening"`
+	}{
+		LibraryItemID: libraryItemID,
+		CurrentTime:   currentTime,
+		StartedAt:     startedAt,
+		LastUpdate:    lastUpdate,
+	})
+}
+
+// addListeningSession appends a listening session to a user progress fixture;
+// see addMediaProgress for why.
+func addListeningSession(up *models.AudiobookshelfUserProgress, libraryItemID string, currentTime float64, startedAt, updatedAt int64) {
+	up.ListeningSessions = append(up.ListeningSessions, struct {
+		ID            string `json:"id"`
+		UserID        string `json:"userId"`
+		LibraryItemID string `json:"libraryItemId"`
+		MediaType     string `json:"mediaType"`
+		MediaMetadata struct {
+			Title  string `json:"title"`
+			Author string `json:"author"`
+		} `json:"mediaMetadata"`
+		Duration    float64 `json:"duration"`
+		CurrentTime float64 `json:"currentTime"`
+		Progress    float64 `json:"progress"`
+		IsFinished  bool    `json:"isFinished"`
+		StartedAt   int64   `json:"startedAt"`
+		UpdatedAt   int64   `json:"updatedAt"`
+	}{
+		LibraryItemID: libraryItemID,
+		CurrentTime:   currentTime,
+		StartedAt:     startedAt,
+		UpdatedAt:     updatedAt,
+	})
+}
+
+func TestProcessBookMergesUserProgressBeforeUnreadSkip(t *testing.T) {
+	svc, mockClient := createTestService()
+	svc.config.Sync.Incremental = false
+	svc.config.Sync.ProcessUnreadBooks = false
+
+	// The library item reports no playback, but the authoritative /me media
+	// progress says the book is started. The merge must happen before the
+	// unread skip, so the book has to reach the Hardcover lookup.
+	book := toAudiobookshelfBook(createTestBook("started-book", "Started Book", "Test Author", "ASIN123", ""))
+	book.Progress.CurrentTime = 0
+	book.Progress.IsFinished = false
+
+	userProgress := &models.AudiobookshelfUserProgress{}
+	addMediaProgress(userProgress, book.ID, 120, 0, 200)
+
+	mockClient.On("SearchBookByASIN", mock.Anything, "ASIN123").Return((*models.HardcoverBook)(nil), assert.AnError)
+	mockClient.On("SearchBooks", mock.Anything, mock.Anything, mock.Anything).Return([]models.HardcoverBook{}, nil)
+
+	_ = svc.processBook(context.Background(), *book, userProgress)
+
+	mockClient.AssertCalled(t, "SearchBookByASIN", mock.Anything, "ASIN123")
+}
+
+func TestEnhanceBookProgressFromUserData(t *testing.T) {
+	svc, _ := createTestService()
+
+	t.Run("prefers media progress over listening session", func(t *testing.T) {
+		book := toAudiobookshelfBook(createTestBook("progress-book", "Progress Book", "Test Author", "", ""))
+		userProgress := &models.AudiobookshelfUserProgress{}
+		addMediaProgress(userProgress, book.ID, 120, 100, 200)
+		// The session is more recently updated, but media progress must win.
+		addListeningSession(userProgress, book.ID, 60, 50, 300)
+
+		svc.enhanceBookProgressFromUserData(book, userProgress, logger.Get())
+
+		assert.Equal(t, 120.0, book.Progress.CurrentTime)
+		assert.Equal(t, int64(100), book.Progress.StartedAt)
+	})
+
+	t.Run("session fallback preserves library StartedAt", func(t *testing.T) {
+		// When no media progress matches, the session supplies
+		// CurrentTime/IsFinished but must not overwrite the library StartedAt —
+		// a session's startedAt is when playback began, not when the read began.
+		book := toAudiobookshelfBook(createTestBook("progress-book", "Progress Book", "Test Author", "", ""))
+		book.Progress.StartedAt = 999
+		userProgress := &models.AudiobookshelfUserProgress{}
+		addListeningSession(userProgress, book.ID, 60, 50, 300)
+
+		svc.enhanceBookProgressFromUserData(book, userProgress, logger.Get())
+
+		assert.Equal(t, 60.0, book.Progress.CurrentTime)
+		assert.Equal(t, int64(999), book.Progress.StartedAt)
+	})
 }
 
 func TestProcessFoundBook_WithBook(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes

Skips unstarted books before calling the Hardcover API instead of after to save throttling and API calls.

Previously, when `process_unread_books` was disabled, every library item was sync-checked as to whether or not the book had been started — making a lot of unneeded API calls and creating "book not matched" mismatch logging records for books that were about to be skipped. 

These changes build on the recent `enhanceBookProgressFromUserData` change on `develop:` since progress is already merged from `/api/me` early, the unread check can now run before any lookup.

Also: books skipped by the unread filter are no longer counted in the `BooksSynced` summary stat (they still count toward total books processed).

## Testing Instructions

- `go test ./...` — all tests pass, including three new/updated ones:
  - `TestProcessBookSkipsUnreadBeforeHardcoverLookup`: an unstarted book
    triggers no Hardcover search calls and doesn't count as synced.
  - `TestProcessBookMergesUserProgressBeforeUnreadSkip`: a book with no
    progress in the library payload but progress in `/me` is NOT skipped and
    reaches the Hardcover lookup (pins the merge-before-skip ordering).
  - `TestEnhanceBookProgressFromUserData`: media progress takes precedence
    over listening sessions; the session fallback preserves the library
    item's `StartedAt`.
- Manual check: set `process_unread_books: false`, enable debug logging, and
  run a sync against a library containing unstarted books. Unstarted books
  log "Skipping unstarted book before Hardcover lookup" with no preceding
  Hardcover search requests, and the summary no longer counts them as synced.

## Checklist
- [X] Tests pass locally
- [x] Tests pass on CI
- [x] Code quality checks pass on CI
- [x] Documentation is updated
- [X] Changelog is updated