### PR TITLE
Limit raw API response logging to debug

### DIFF
--- a/internal/api/audiobookshelf/client.go
+++ b/internal/api/audiobookshelf/client.go
@@ -208,10 +208,11 @@ func (c *Client) GetLibraryItems(ctx context.Context, libraryID string) ([]model
 		})
 	}
 
-	// Print the raw response directly to stderr to ensure it's captured
-	os.Stderr.WriteString("\n=== START OF RAW API RESPONSE ===\n")
-	os.Stderr.Write(body)
-	os.Stderr.WriteString("\n=== END OF RAW API RESPONSE ===\n\n")
+	// Keep the full response available for troubleshooting without exposing it
+	// during normal operation.
+	log.Debug("Raw API response from Audiobookshelf", map[string]interface{}{
+		"response": string(body),
+	})
 
 	// Save to a file in the current directory using absolute path
 	absPath := "/tmp/audiobookshelf_raw_response.json"


### PR DESCRIPTION
## Summary

Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. This keeps normal logs concise while preserving the raw response for troubleshooting when debug logging is enabled.

## What Changed

- Replaced the unconditional raw API response dump to standard error with a debug-level log entry.
- Preserved the complete response body in the debug log for diagnostics.

## Why

The direct standard-error write bypassed the configured log level and exposed a potentially large raw API payload during normal operation. Using the existing logger honors the application's logging configuration while retaining diagnostic visibility at debug level.