### PR TITLE
fix: correct rate limiter pacing and recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,6 @@ SHUTDOWN_TIMEOUT=10s
 # Minimum time between requests (30 requests per minute)
 RATE_LIMIT_RATE=2s
 
-# Maximum number of requests in a burst
-RATE_LIMIT_BURST=1
-
 # Maximum number of concurrent requests
 RATE_LIMIT_MAX_CONCURRENT=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - **Limit raw API response logging to debug**: Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. (#174)
 - **Prevent Hardcover mutations during dry runs**: dry_run was not working correctly. Prevent dry-run syncs from calling Hardcover mutation APIs while preserving the read operations needed to report intended changes, and identify active dry runs on the Sync Status page. (#175)
-- **Correct rate limiter pacing and recovery**: Corrects Hardcover API pacing so rate-limit handling remains bounded, responds to authoritative server guidance, and recovers cleanly after throttling. This prevents concurrent waits from accelerating requests and prevents incomplete or unguided rate-limit responses from leaving syncs indefinitely stalled or incorrectly paced. (#176)
+- **Correct rate limiter pacing and recovery**: Corrects Hardcover API pacing so rate-limit handling remains bounded, responds to authoritative server guidance, and recovers cleanly after throttling. This prevents concurrent waits from accelerating requests and prevents incomplete or unguided rate-limit responses from leaving syncs indefinitely stalled or incorrectly paced. Removes the obsolete burst setting and unused token-bucket state; admission is governed by request pacing and concurrency. (#176)
 
 ## [v3.6.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - **Limit raw API response logging to debug**: Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. (#174)
 - **Prevent Hardcover mutations during dry runs**: dry_run was not working correctly. Prevent dry-run syncs from calling Hardcover mutation APIs while preserving the read operations needed to report intended changes, and identify active dry runs on the Sync Status page. (#175)
+- **Correct rate limiter pacing and recovery**: Corrects Hardcover API pacing so rate-limit handling remains bounded, responds to authoritative server guidance, and recovers cleanly after throttling. This prevents concurrent waits from accelerating requests and prevents incomplete or unguided rate-limit responses from leaving syncs indefinitely stalled or incorrectly paced. (#176)
 
 ## [v3.6.0] - 2026-09-01
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,6 +41,8 @@ If you previously used environment variables for configuration, you will need to
 
 - **`HARDCOVER_SYNC_DELAY_MS`**: Replaced with request pacing and concurrency limiting
   - **Migration**: Use the rate limiting configuration in `config.yaml` instead
+- **`RATE_LIMIT_BURST` / `rate_limit.burst`**: This setting has been removed and no longer has any effect
+  - **Migration**: Delete it from your environment or YAML configuration. To adjust rate limiting, use `RATE_LIMIT_RATE` / `rate_limit.rate` to control how often requests are sent and `RATE_LIMIT_MAX_CONCURRENT` / `rate_limit.max_concurrent` to limit simultaneous requests.
 - **`AUDIOBOOK_MATCH_MODE`**: This legacy option has been removed
   - **Migration**: No action needed, improved matching is now the default
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,7 +39,7 @@ If you previously used environment variables for configuration, you will need to
 
 ### Removed Environment Variables
 
-- **`HARDCOVER_SYNC_DELAY_MS`**: Replaced with token bucket rate limiting
+- **`HARDCOVER_SYNC_DELAY_MS`**: Replaced with request pacing and concurrency limiting
   - **Migration**: Use the rate limiting configuration in `config.yaml` instead
 - **`AUDIOBOOK_MATCH_MODE`**: This legacy option has been removed
   - **Migration**: No action needed, improved matching is now the default

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,7 +48,6 @@ If you previously used environment variables for configuration, you will need to
 
 - **`HARDCOVER_BASE_URL`**: Override the Hardcover GraphQL API base URL (default: https://api.hardcover.app/v1/graphql)
 - **`RATE_LIMIT_RATE`**: Minimum time between Hardcover API requests (e.g., `2s` for 30 requests/minute)
-- **`RATE_LIMIT_BURST`**: Maximum burst size for requests (e.g., `2`)
 - **`RATE_LIMIT_MAX_CONCURRENT`**: Maximum number of concurrent requests (e.g., `3`)
 - **`CONFIG_FILE`**: Path to the configuration file (default: "./config.yaml")
 
@@ -178,7 +177,6 @@ sync:
   ```yaml
   rate_limit:
     rate: "3000ms"  # Increase this value to slow down requests
-    burst: 1        # Reduce burst capacity
   ```
 
 ### Progress Not Syncing

--- a/README.md
+++ b/README.md
@@ -493,7 +493,6 @@ server:
 # Rate limiting configuration
 rate_limit:
   rate: "2s"            # Minimum time between requests (30 requests per minute)
-  burst: 1              # Maximum number of requests in a burst
   max_concurrent: 1     # Maximum number of concurrent requests
 
 # Logging configuration
@@ -606,7 +605,6 @@ paths:
 | `LOG_FORMAT` | Log output format | `json` | `json`, `text` |
 | `HARDCOVER_BASE_URL` | Hardcover GraphQL API base URL | `https://api.hardcover.app/v1/graphql` | `https://api.hardcover.app/v1/graphql` |
 | `RATE_LIMIT_RATE` | Minimum time between Hardcover API requests | unset | `2s` (30 rpm) |
-| `RATE_LIMIT_BURST` | Max burst size for requests | unset | `1` |
 | `RATE_LIMIT_MAX_CONCURRENT` | Max concurrent requests | unset | `1` |
 
 **Single-User Mode (Legacy)** - For backwards compatibility (web UI disabled):
@@ -662,7 +660,6 @@ hardcover:
 | `HARDCOVER_TOKEN` | Hardcover API token | `hardcover.token` | Legacy mode only |
 | `HARDCOVER_BASE_URL` | Hardcover API base URL | `hardcover.base_url` | Override default endpoint |
 | `RATE_LIMIT_RATE` | Min time between requests | `rate_limit.rate` | e.g. `2s` (30 rpm) |
-| `RATE_LIMIT_BURST` | Burst size | `rate_limit.burst` | e.g. `1` |
 | `RATE_LIMIT_MAX_CONCURRENT` | Max concurrent requests | `rate_limit.max_concurrent` | e.g. `1` |
 | `SYNC_INTERVAL` | Time between automatic syncs | `sync.sync_interval` | Legacy mode only |
 | `SYNC_INCLUDE_EBOOKS` | Include items with media type "ebook" | `sync.include_ebooks` | Legacy mode only |

--- a/cmd/audiobookshelf-hardcover-sync/main.go
+++ b/cmd/audiobookshelf-hardcover-sync/main.go
@@ -321,9 +321,6 @@ func main() {
 		if cfg.RateLimit.Rate > 0 {
 			hcCfg.RateLimit = cfg.RateLimit.Rate
 		}
-		if cfg.RateLimit.Burst > 0 {
-			hcCfg.Burst = cfg.RateLimit.Burst
-		}
 		if cfg.RateLimit.MaxConcurrent > 0 {
 			hcCfg.MaxConcurrent = cfg.RateLimit.MaxConcurrent
 		}
@@ -331,7 +328,6 @@ func main() {
 		log.Debug("Initializing Hardcover client (single-user)", map[string]interface{}{
 			"base_url":       hcCfg.BaseURL,
 			"rate_limit":     hcCfg.RateLimit.String(),
-			"burst":          hcCfg.Burst,
 			"max_concurrent": hcCfg.MaxConcurrent,
 		})
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,6 @@ server:
 # Rate limiting configuration
 rate_limit:
   rate: "2s"            # Minimum time between requests (30 requests per minute)
-  burst: 1              # Maximum number of requests in a burst
   max_concurrent: 1     # Maximum number of concurrent requests
 
 # Logging configuration

--- a/helm/audiobookshelf-hardcover-sync/README.md
+++ b/helm/audiobookshelf-hardcover-sync/README.md
@@ -183,7 +183,6 @@ See the [Authentication Guide](../../docs/AUTHENTICATION.md) for detailed setup 
 | `config.server.port`                    | Server port                                                | `"8080"`           |
 | `config.server.shutdownTimeout`         | Graceful shutdown timeout                                  | `"10s"`            |
 | `config.rateLimit.rate`                 | Minimum time between requests                              | `"1500ms"`         |
-| `config.rateLimit.burst`                | Maximum number of requests in a burst                      | `2`                |
 | `config.rateLimit.maxConcurrent`        | Maximum number of concurrent requests                      | `3`                |
 | `config.logging.level`                  | Log level                                                  | `"info"`           |
 | `config.logging.format`                 | Log format                                                 | `"json"`           |

--- a/helm/audiobookshelf-hardcover-sync/templates/configmap.yaml
+++ b/helm/audiobookshelf-hardcover-sync/templates/configmap.yaml
@@ -14,7 +14,6 @@ data:
     # Rate limiting configuration
     rate_limit:
       rate: {{ .Values.config.rateLimit.rate | quote }}
-      burst: {{ .Values.config.rateLimit.burst }}
       max_concurrent: {{ .Values.config.rateLimit.maxConcurrent }}
 
     # Logging configuration

--- a/helm/audiobookshelf-hardcover-sync/templates/deployment.yaml
+++ b/helm/audiobookshelf-hardcover-sync/templates/deployment.yaml
@@ -56,8 +56,6 @@ spec:
             # Rate limiting configuration
             - name: RATE_LIMIT_RATE
               value: {{ .Values.config.rateLimit.rate | quote }}
-            - name: RATE_LIMIT_BURST
-              value: {{ .Values.config.rateLimit.burst | quote }}
             - name: RATE_LIMIT_MAX_CONCURRENT
               value: {{ .Values.config.rateLimit.maxConcurrent | quote }}
             

--- a/helm/audiobookshelf-hardcover-sync/values.yaml
+++ b/helm/audiobookshelf-hardcover-sync/values.yaml
@@ -238,7 +238,6 @@ config:
   # Rate limiting configuration
   rateLimit:
     rate: "1500ms"        # Minimum time between requests
-    burst: 2              # Maximum number of requests in a burst
     maxConcurrent: 3      # Maximum number of concurrent requests
 
   # Logging configuration

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -117,8 +117,6 @@ const (
 	// DefaultRateLimit is the default minimum time between requests.
 	// Hardcover now enforces 30 requests/minute, so use 2s between requests.
 	DefaultRateLimit = 2 * time.Second
-	// DefaultBurst is the default burst size for rate limiting
-	DefaultBurst = 1
 	// DefaultMaxConcurrent is the default maximum concurrent requests
 	DefaultMaxConcurrent = 1
 )
@@ -135,8 +133,6 @@ type ClientConfig struct {
 	RetryDelay time.Duration
 	// RateLimit specifies the minimum time between requests (default: from config or DefaultRateLimit)
 	RateLimit time.Duration
-	// Burst specifies the burst size for rate limiting (default: from config or DefaultBurst)
-	Burst int
 	// MaxConcurrent specifies the maximum number of concurrent requests (default: from config or 3)
 	MaxConcurrent int
 }
@@ -233,7 +229,6 @@ func DefaultClientConfig() *ClientConfig {
 		MaxRetries:    DefaultMaxRetries,
 		RetryDelay:    DefaultRetryDelay,
 		RateLimit:     DefaultRateLimit,     // Use hardcoded default
-		Burst:         DefaultBurst,         // Use hardcoded default
 		MaxConcurrent: DefaultMaxConcurrent, // Use hardcoded default
 	}
 }
@@ -271,7 +266,7 @@ func NewClientWithConfig(cfg *ClientConfig, token string, log *logger.Logger) *C
 	}
 
 	// Create rate limiter with max concurrent requests from config
-	rateLimiter := util.NewRateLimiter(cfg.RateLimit, cfg.Burst, cfg.MaxConcurrent, log)
+	rateLimiter := util.NewRateLimiter(cfg.RateLimit, cfg.MaxConcurrent, log)
 
 	// Create logger if not provided
 	if log == nil {

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -348,10 +348,10 @@ func NewClientWithConfig(cfg *ClientConfig, token string, log *logger.Logger) *C
 // enforceRateLimit ensures we don't exceed the API rate limits
 func (c *Client) enforceRateLimit(ctx context.Context) error {
 	// Simply use the rate limiter which already handles:
-	// - Token bucket algorithm
-	// - Jitter
+	// - Request pacing and server-guided backoff
 	// - Context cancellation
 	// - Dynamic rate adjustment
+	// - Concurrent request admission
 	return c.rateLimiter.Wait(ctx)
 }
 

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -536,8 +536,8 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 		// Read the response body
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		release()
 		if err != nil {
+			release()
 			lastErr = fmt.Errorf("failed to read response body: %w", err)
 			c.logger.Error("Failed to read response body", map[string]interface{}{
 				"error":   lastErr.Error(),
@@ -557,6 +557,7 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 		// Process rate limit headers from EVERY response so the rate limiter
 		// can self-throttle proactively before hitting HTTP 429.
 		c.rateLimiter.WithRateLimitHeaders(resp)
+		release()
 
 		// Check for HTTP errors
 		if resp.StatusCode >= 400 {

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -425,30 +425,6 @@ func isRetryableHTTPStatus(statusCode int) bool {
 	return statusCode == http.StatusTooManyRequests || (statusCode >= 500 && statusCode <= 599)
 }
 
-func parseRetryAfterDelay(value string) (time.Duration, bool) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0, false
-	}
-
-	if seconds, err := strconv.Atoi(value); err == nil {
-		if seconds < 0 {
-			seconds = 0
-		}
-		return time.Duration(seconds) * time.Second, true
-	}
-
-	if retryAt, err := http.ParseTime(value); err == nil {
-		delay := time.Until(retryAt)
-		if delay < 0 {
-			delay = 0
-		}
-		return delay, true
-	}
-
-	return 0, false
-}
-
 // GraphQLQuery executes a GraphQL query and unmarshals the response into the result parameter
 func (c *Client) GraphQLQuery(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
 	if variables == nil {
@@ -505,11 +481,6 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 			}
 		}
 
-		// Apply rate limiting
-		if err := c.rateLimiter.Wait(ctx); err != nil {
-			return fmt.Errorf("rate limiter error: %w", err)
-		}
-
 		// Create the request body
 		reqBody := map[string]interface{}{
 			"query":     query,
@@ -544,9 +515,16 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 			"body": string(jsonBody),
 		})
 
+		// Apply pacing and acquire a permit for the active HTTP request.
+		release, err := c.rateLimiter.Acquire(ctx)
+		if err != nil {
+			return fmt.Errorf("rate limiter error: %w", err)
+		}
+
 		// Execute the request
 		resp, err := httpClient.Do(req)
 		if err != nil {
+			release()
 			lastErr = fmt.Errorf("HTTP request failed: %w", err)
 			c.logger.Error("GraphQL request failed", map[string]interface{}{
 				"error":   lastErr.Error(),
@@ -558,6 +536,7 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 		// Read the response body
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
+		release()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response body: %w", err)
 			c.logger.Error("Failed to read response body", map[string]interface{}{
@@ -593,19 +572,6 @@ func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperatio
 				return fmt.Errorf("non-retryable HTTP error: %w", lastErr)
 			}
 
-			if resp.StatusCode == http.StatusTooManyRequests {
-				if retryAfter, ok := parseRetryAfterDelay(resp.Header.Get("Retry-After")); ok {
-					genericDelay := c.retryDelay * time.Duration(attempt+1)
-					if retryAfter > genericDelay {
-						extraDelay := retryAfter - genericDelay
-						select {
-						case <-ctx.Done():
-							return fmt.Errorf("retry canceled: %w", ctx.Err())
-						case <-time.After(extraDelay):
-						}
-					}
-				}
-			}
 			continue
 		}
 

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -165,17 +165,17 @@ const (
 // Client represents a client for the Hardcover API
 // Client represents a client for the Hardcover API
 type Client struct {
-	baseURL          string
-	authToken        string
-	dryRun           bool
-	httpClient       *http.Client
-	gqlClient        *graphql.Client
-	logger           *logger.Logger
-	currentUserID    int
-	currentUserMutex sync.RWMutex
-	rateLimiter      *util.RateLimiter
-	maxRetries       int
-	retryDelay       time.Duration
+	baseURL               string
+	authToken             string
+	dryRun                bool
+	httpClient            *http.Client
+	gqlClient             *graphql.Client
+	logger                *logger.Logger
+	currentUserID         int
+	currentUserMutex      sync.RWMutex
+	rateLimiter           *util.RateLimiter
+	maxRetries            int
+	retryDelay            time.Duration
 	userBookIDCache       cache.Cache[int, int]             // editionID -> userBookID
 	userBookByBookIDCache cache.Cache[int, int]             // bookID -> userBookID
 	userCache             cache.Cache[string, any]          // Generic cache for user-specific data
@@ -345,16 +345,6 @@ func NewClientWithConfig(cfg *ClientConfig, token string, log *logger.Logger) *C
 	return client
 }
 
-// enforceRateLimit ensures we don't exceed the API rate limits
-func (c *Client) enforceRateLimit(ctx context.Context) error {
-	// Simply use the rate limiter which already handles:
-	// - Request pacing and server-guided backoff
-	// - Context cancellation
-	// - Dynamic rate adjustment
-	// - Concurrent request admission
-	return c.rateLimiter.Wait(ctx)
-}
-
 // loggingRoundTripper is a custom http.RoundTripper that logs requests and responses
 type loggingRoundTripper struct {
 	logger *logger.Logger
@@ -454,12 +444,22 @@ func (c *Client) GraphQLMutation(ctx context.Context, mutation string, variables
 
 // executeGraphQLOperation is a helper function that handles the common logic for executing GraphQL operations
 func (c *Client) executeGraphQLOperation(ctx context.Context, op graphqlOperation, query string, variables map[string]interface{}, result interface{}) error {
-	// Create a new GraphQL client with logging transport
-	httpClient := &http.Client{
-		Transport: loggingRoundTripper{
-			logger: c.logger,
-			rt:     http.DefaultTransport,
-		},
+	// Preserve the configured client (including timeout, redirects, cookies, and
+	// custom transport) while adding request/response logging around its
+	// transport. A few tests and callers construct Client values directly, so
+	// retain a safe default when no HTTP client or transport is configured.
+	httpClient := &http.Client{}
+	if c.httpClient != nil {
+		clientCopy := *c.httpClient
+		httpClient = &clientCopy
+	}
+	transport := httpClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	httpClient.Transport = loggingRoundTripper{
+		logger: c.logger,
+		rt:     transport,
 	}
 
 	// Set the authorization header
@@ -1127,10 +1127,10 @@ func (c *Client) GetUserBook(ctx context.Context, userBookID string) (*models.Ha
 			} `json:"book"`
 			EditionID int `json:"edition_id"`
 			Edition   struct {
-				ID     int     `json:"id"`
-				ASIN   *string `json:"asin"`
-				ISBN13 *string `json:"isbn_13"`
-				ISBN10 *string `json:"isbn_10"`
+				ID           int     `json:"id"`
+				ASIN         *string `json:"asin"`
+				ISBN13       *string `json:"isbn_13"`
+				ISBN10       *string `json:"isbn_10"`
 				BookMappings []struct {
 					ExternalID string `json:"external_id"`
 					Platform   struct {
@@ -2572,15 +2572,15 @@ func (c *Client) GetEdition(ctx context.Context, editionID string) (*models.Edit
 	// should match what's inside the data field
 	var response struct {
 		Editions []struct {
-			ID             int     `json:"id"`
-			BookID         int     `json:"book_id"`
-			Title          *string `json:"title"`
-			ISBN10         *string `json:"isbn_10"`
-			ISBN13         *string `json:"isbn_13"`
-			ASIN           *string `json:"asin"`
-			ReleaseDate    *string `json:"release_date"`
+			ID              int     `json:"id"`
+			BookID          int     `json:"book_id"`
+			Title           *string `json:"title"`
+			ISBN10          *string `json:"isbn_10"`
+			ISBN13          *string `json:"isbn_13"`
+			ASIN            *string `json:"asin"`
+			ReleaseDate     *string `json:"release_date"`
 			ReadingFormatID *int    `json:"reading_format_id"`
-			BookMappings   []struct {
+			BookMappings    []struct {
 				ExternalID string `json:"external_id"`
 				Platform   struct {
 					Name string `json:"name"`
@@ -2623,13 +2623,13 @@ func (c *Client) GetEdition(ctx context.Context, editionID string) (*models.Edit
 
 	// Log the raw edition data for debugging
 	log.Debug("Retrieved edition details", map[string]interface{}{
-		"id":               edition.ID,
-		"book_id":          edition.BookID,
-		"title":            safeString(edition.Title),
-		"isbn_10":          safeString(edition.ISBN10),
-		"isbn_13":          safeString(edition.ISBN13),
-		"asin":             safeString(edition.ASIN),
-		"release_date":     safeString(edition.ReleaseDate),
+		"id":                edition.ID,
+		"book_id":           edition.BookID,
+		"title":             safeString(edition.Title),
+		"isbn_10":           safeString(edition.ISBN10),
+		"isbn_13":           safeString(edition.ISBN13),
+		"asin":              safeString(edition.ASIN),
+		"release_date":      safeString(edition.ReleaseDate),
 		"reading_format_id": edition.ReadingFormatID,
 	})
 
@@ -3034,10 +3034,10 @@ func (c *Client) GetUserBookID(ctx context.Context, editionID int) (int, error) 
 	userBookID, err := c.lookupUserBookByBookID(ctx, bookID, editionID, userID)
 	if err != nil {
 		log.Warn("Failed to lookup user book by book ID and edition ID", map[string]interface{}{
-			"bookID": bookID,
+			"bookID":    bookID,
 			"editionID": editionID,
-			"userID": userID,
-			"error":  err.Error(),
+			"userID":    userID,
+			"error":     err.Error(),
 		})
 		return 0, fmt.Errorf("failed to lookup user book by book ID and edition ID: %w", err)
 	}
@@ -3176,10 +3176,10 @@ func (c *Client) ClearUserBookCache() {
 // lookupUserBookByBookID performs a single lookup of a user book by book ID and edition ID
 func (c *Client) lookupUserBookByBookID(ctx context.Context, bookID, editionID, userID int) (int, error) {
 	log := c.logger.With(map[string]interface{}{
-		"bookID": bookID,
+		"bookID":    bookID,
 		"editionID": editionID,
-		"userID": userID,
-		"method": "lookupUserBookByBookID",
+		"userID":    userID,
+		"method":    "lookupUserBookByBookID",
 	})
 
 	// Define the GraphQL query - look for user book with both book_id and edition_id

--- a/internal/api/hardcover/client.go
+++ b/internal/api/hardcover/client.go
@@ -2862,11 +2862,6 @@ func (c *Client) SearchPublishers(ctx context.Context, name string, limit int) (
 		"limit":     limit,
 	})
 
-	// Enforce rate limiting
-	if err := c.enforceRateLimit(ctx); err != nil {
-		return nil, fmt.Errorf("rate limit error: %w", err)
-	}
-
 	// Define the GraphQL query
 	// Note: Using _eq for exact match as _ilike is not supported by the API
 	query := `

--- a/internal/api/hardcover/client_config_test.go
+++ b/internal/api/hardcover/client_config_test.go
@@ -19,7 +19,6 @@ func TestDefaultClientConfig(t *testing.T) {
 	assert.Equal(t, DefaultMaxRetries, cfg.MaxRetries)
 	assert.Equal(t, DefaultRetryDelay, cfg.RetryDelay)
 	assert.Equal(t, 2*time.Second, cfg.RateLimit) // 30 requests/minute
-	assert.Equal(t, 1, cfg.Burst)
 	assert.Equal(t, 1, cfg.MaxConcurrent)
 }
 
@@ -59,7 +58,6 @@ func TestNewClientWithConfig(t *testing.T) {
 				MaxRetries:    5,
 				RetryDelay:    1 * time.Second,
 				RateLimit:     200 * time.Millisecond,
-				Burst:         5,
 				MaxConcurrent: 2,
 			},
 			token: "custom-token",
@@ -142,7 +140,6 @@ func TestClient_enforceRateLimit(t *testing.T) {
 		MaxRetries:    DefaultMaxRetries,
 		RetryDelay:    DefaultRetryDelay,
 		RateLimit:     10 * time.Millisecond, // Very short for testing
-		Burst:         1,
 		MaxConcurrent: 1,
 	}
 

--- a/internal/api/hardcover/client_config_test.go
+++ b/internal/api/hardcover/client_config_test.go
@@ -1,7 +1,6 @@
 package hardcover
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -12,7 +11,7 @@ import (
 
 func TestDefaultClientConfig(t *testing.T) {
 	cfg := DefaultClientConfig()
-	
+
 	require.NotNil(t, cfg)
 	assert.Equal(t, DefaultBaseURL, cfg.BaseURL)
 	assert.Equal(t, DefaultTimeout, cfg.Timeout)
@@ -126,38 +125,4 @@ func TestClient_GetAuthHeader(t *testing.T) {
 			assert.Equal(t, tt.expected, header)
 		})
 	}
-}
-
-func TestClient_enforceRateLimit(t *testing.T) {
-	// Initialize logger for test
-	logger.Setup(logger.Config{Level: "debug", Format: "json"})
-	log := logger.Get()
-
-	// Create a client with a very short rate limit for testing
-	cfg := &ClientConfig{
-		BaseURL:       DefaultBaseURL,
-		Timeout:       DefaultTimeout,
-		MaxRetries:    DefaultMaxRetries,
-		RetryDelay:    DefaultRetryDelay,
-		RateLimit:     10 * time.Millisecond, // Very short for testing
-		MaxConcurrent: 1,
-	}
-
-	client := NewClientWithConfig(cfg, "test-token", log)
-
-	// Test that rate limiting doesn't error
-	err1 := client.enforceRateLimit(context.Background())
-	assert.NoError(t, err1)
-
-	// Test multiple rapid calls
-	start := time.Now()
-	err2 := client.enforceRateLimit(context.Background())
-	assert.NoError(t, err2)
-	err3 := client.enforceRateLimit(context.Background())
-	assert.NoError(t, err3)
-	duration := time.Since(start)
-
-	// The second and third calls should have been rate limited,
-	// so the total duration should be at least the rate limit duration
-	assert.GreaterOrEqual(t, duration, cfg.RateLimit)
 }

--- a/internal/api/hardcover/client_graphql_test.go
+++ b/internal/api/hardcover/client_graphql_test.go
@@ -286,6 +286,47 @@ func TestGraphQLQuery_BoundsRetryAfterPause(t *testing.T) {
 	assert.Equal(t, 1, response.Books[0].ID)
 }
 
+func TestGraphQLQuery_DailyResetOverridesRetryAfter(t *testing.T) {
+	logger.Setup(logger.Config{Level: "error", Format: "json"})
+	log := logger.Get()
+
+	previousMaxBackoff := util.DefaultMaxBackoff
+	util.DefaultMaxBackoff = 25 * time.Millisecond
+	t.Cleanup(func() { util.DefaultMaxBackoff = previousMaxBackoff })
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.Header().Set("RateLimit", `"Free";r=59;t=1, "daily";r=0;t=1`)
+			w.Header().Set("RateLimit-Policy", `"Free";q=60;w=60, "daily";q=5000;w=86400`)
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"books":[{"id":1}]}}`))
+	}))
+	defer server.Close()
+
+	client := CreateTestClient(server)
+	client.logger = log
+	client.maxRetries = 1
+	client.retryDelay = time.Millisecond
+	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 1, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	var response struct {
+		Books []struct {
+			ID int `json:"id"`
+		} `json:"books"`
+	}
+
+	err := client.GraphQLQuery(ctx, `query DailyResetTest { books { id } }`, nil, &response)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
 func TestGraphQLQuery_MaxConcurrentLimitsActiveRequests(t *testing.T) {
 	logger.Setup(logger.Config{Level: "error", Format: "json"})
 	log := logger.Get()

--- a/internal/api/hardcover/client_graphql_test.go
+++ b/internal/api/hardcover/client_graphql_test.go
@@ -202,7 +202,7 @@ func TestGraphQLQuery_RetriesOn429ThenSucceeds(t *testing.T) {
 	client.logger = log
 	client.maxRetries = 3
 	client.retryDelay = 1 * time.Millisecond
-	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 100, 100, log)
+	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 100, log)
 
 	var response struct {
 		Books []struct {
@@ -232,7 +232,7 @@ func TestGraphQLQuery_FailsFastOn400(t *testing.T) {
 	client.logger = log
 	client.maxRetries = 3
 	client.retryDelay = 1 * time.Millisecond
-	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 100, 100, log)
+	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 100, log)
 
 	var response struct {
 		Books []struct {

--- a/internal/api/hardcover/client_graphql_test.go
+++ b/internal/api/hardcover/client_graphql_test.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,28 +34,28 @@ func TestGraphQLQuery_BookByASIN(t *testing.T) {
 		// Read the request body once
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err, "Error reading request body")
-		
+
 		// Create a new reader with the body content for parsing
 		r.Body = io.NopCloser(strings.NewReader(string(body)))
-		
+
 		// Check if it's a GetCurrentUserID query first
 		if HandleGetCurrentUserIDQuery(t, w, r) {
 			return
 		}
-		
+
 		// Reuse the body content for our own parsing
 		r.Body = io.NopCloser(strings.NewReader(string(body)))
-		
+
 		// Parse the request body to check if it's the ASIN query
 		var reqBody struct {
 			Query     string                 `json:"query"`
 			Variables map[string]interface{} `json:"variables"`
 		}
-		
+
 		// Decode the request body
 		err = json.NewDecoder(r.Body).Decode(&reqBody)
 		require.NoError(t, err, "Error decoding request body")
-		
+
 		// Check if this is our ASIN query
 		if _, ok := reqBody.Variables["asin"]; ok {
 			// Create a simple JSON response that matches the expected structure
@@ -81,7 +81,7 @@ func TestGraphQLQuery_BookByASIN(t *testing.T) {
 					]
 				}
 			}`
-			
+
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(responseJSON))
 			if err != nil {
@@ -89,7 +89,7 @@ func TestGraphQLQuery_BookByASIN(t *testing.T) {
 			}
 			return
 		}
-		
+
 		// If we get here, it's an unknown query
 		http.Error(w, "Unexpected query", http.StatusBadRequest)
 	}))
@@ -164,7 +164,7 @@ func TestGraphQLQuery_BookByASIN(t *testing.T) {
 	// Execute the query
 	err := client.GraphQLQuery(context.Background(), query, variables, &response)
 	require.NoError(t, err, "GraphQL query should not return an error")
-	
+
 	t.Logf("Response received: %+v", response)
 
 	// Assert the response
@@ -398,4 +398,84 @@ func TestGraphQLQuery_MaxConcurrentLimitsActiveRequests(t *testing.T) {
 	require.NoError(t, <-errs)
 	require.NoError(t, <-errs)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&maxActive))
+}
+
+func TestGraphQLQuery_UsesConfiguredTimeoutAndReleasesPermit(t *testing.T) {
+	logger.Setup(logger.Config{Level: "error", Format: "json"})
+	log := logger.Get()
+
+	var requests int32
+	firstStarted := make(chan struct{})
+	firstFinished := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch atomic.AddInt32(&requests, 1) {
+		case 1:
+			close(firstStarted)
+			// Keep the handler stalled longer than the configured client timeout.
+			// Do not rely on the server observing the client-side connection close.
+			time.Sleep(200 * time.Millisecond)
+			close(firstFinished)
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":{"books":[{"id":1}]}}`)
+		default:
+			t.Errorf("unexpected request count: %d", atomic.LoadInt32(&requests))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithConfig(&ClientConfig{
+		BaseURL:       server.URL,
+		Timeout:       25 * time.Millisecond,
+		MaxRetries:    0,
+		RetryDelay:    time.Millisecond,
+		RateLimit:     time.Nanosecond,
+		MaxConcurrent: 1,
+	}, "test-token", log)
+
+	var firstResponse struct {
+		Books []struct {
+			ID int `json:"id"`
+		} `json:"books"`
+	}
+	firstErr := make(chan error, 1)
+	startedAt := time.Now()
+	go func() {
+		firstErr <- client.GraphQLQuery(context.Background(), `query TimeoutTest { books { id } }`, nil, &firstResponse)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stalled request did not reach the server")
+	}
+
+	select {
+	case err := <-firstErr:
+		require.Error(t, err)
+		assert.Less(t, time.Since(startedAt), 150*time.Millisecond)
+	case <-time.After(time.Second):
+		t.Fatal("configured HTTP timeout did not end the stalled request")
+	}
+	var secondResponse struct {
+		Books []struct {
+			ID int `json:"id"`
+		} `json:"books"`
+	}
+	secondErr := make(chan error, 1)
+	go func() {
+		secondErr <- client.GraphQLQuery(context.Background(), `query ReusePermit { books { id } }`, nil, &secondResponse)
+	}()
+	select {
+	case err := <-secondErr:
+		require.NoError(t, err)
+		assert.Equal(t, 1, secondResponse.Books[0].ID)
+	case <-time.After(time.Second):
+		t.Fatal("rate-limiter permit was not released after the timed-out request")
+	}
+	select {
+	case <-firstFinished:
+	case <-time.After(time.Second):
+		t.Fatal("stalled test handler did not finish")
+	}
 }

--- a/internal/api/hardcover/client_graphql_test.go
+++ b/internal/api/hardcover/client_graphql_test.go
@@ -245,3 +245,116 @@ func TestGraphQLQuery_FailsFastOn400(t *testing.T) {
 	assert.Equal(t, 1, int(atomic.LoadInt32(&attempts)))
 	assert.Contains(t, err.Error(), "non-retryable HTTP error")
 }
+
+func TestGraphQLQuery_BoundsRetryAfterPause(t *testing.T) {
+	logger.Setup(logger.Config{Level: "error", Format: "json"})
+	log := logger.Get()
+
+	previousMaxBackoff := util.DefaultMaxBackoff
+	util.DefaultMaxBackoff = 25 * time.Millisecond
+	t.Cleanup(func() { util.DefaultMaxBackoff = previousMaxBackoff })
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			w.Header().Set("Retry-After", "5")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"books":[{"id":1}]}}`))
+	}))
+	defer server.Close()
+
+	client := CreateTestClient(server)
+	client.logger = log
+	client.maxRetries = 1
+	client.retryDelay = time.Millisecond
+	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 1, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	var response struct {
+		Books []struct {
+			ID int `json:"id"`
+		} `json:"books"`
+	}
+
+	err := client.GraphQLQuery(ctx, `query RetryAfterTest { books { id } }`, nil, &response)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+	assert.Equal(t, 1, response.Books[0].ID)
+}
+
+func TestGraphQLQuery_MaxConcurrentLimitsActiveRequests(t *testing.T) {
+	logger.Setup(logger.Config{Level: "error", Format: "json"})
+	log := logger.Get()
+
+	var active, maxActive int32
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := atomic.AddInt32(&active, 1)
+		for {
+			previous := atomic.LoadInt32(&maxActive)
+			if current <= previous || atomic.CompareAndSwapInt32(&maxActive, previous, current) {
+				break
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		entered <- struct{}{}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		atomic.AddInt32(&active, -1)
+		_, _ = w.Write([]byte(`{"data":{"books":[{"id":1}]}}`))
+	}))
+	defer server.Close()
+
+	client := CreateTestClient(server)
+	client.logger = log
+	client.rateLimiter = util.NewRateLimiter(time.Nanosecond, 1, log)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var response1, response2 struct {
+		Books []struct {
+			ID int `json:"id"`
+		} `json:"books"`
+	}
+	errs := make(chan error, 2)
+	go func() {
+		errs <- client.GraphQLQuery(ctx, `query ConcurrentTest { books { id } }`, nil, &response1)
+	}()
+	go func() {
+		errs <- client.GraphQLQuery(ctx, `query ConcurrentTest { books { id } }`, nil, &response2)
+	}()
+
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("first request did not reach the server")
+	}
+	select {
+	case <-entered:
+		t.Fatal("second request reached the server while the first was active")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release <- struct{}{}
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("second request did not reach the server after the first completed")
+	}
+	release <- struct{}{}
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxActive))
+}

--- a/internal/api/hardcover/client_methods_test.go
+++ b/internal/api/hardcover/client_methods_test.go
@@ -118,7 +118,7 @@ func newTestClient(t *testing.T) (*Client, *httptest.Server) {
 	}))
 
 	// Create a no-op rate limiter for testing
-	rateLimiter := util.NewRateLimiter(10*time.Millisecond, 10, 10, logger.Get()) // Fast rate limiting for tests
+	rateLimiter := util.NewRateLimiter(10*time.Millisecond, 10, logger.Get()) // Fast rate limiting for tests
 
 	// Create a test logger that writes to a buffer
 	var buf bytes.Buffer

--- a/internal/api/hardcover/get_edition_by_asin_test.go
+++ b/internal/api/hardcover/get_edition_by_asin_test.go
@@ -247,7 +247,7 @@ func TestClient_GetEditionByASIN(t *testing.T) {
 				},
 				logger:          log,
 				// Initialize rate limiter for tests
-				rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+				rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 1, log),
 				// Initialize required caches
 				userBookIDCache: cache.NewMemoryCache[int, int](log),
 				userCache:       cache.NewMemoryCache[string, any](log),

--- a/internal/api/hardcover/get_edition_test.go
+++ b/internal/api/hardcover/get_edition_test.go
@@ -152,7 +152,7 @@ func TestClient_GetEdition(t *testing.T) {
 				},
 				logger: log,
 				// Initialize rate limiter for tests
-				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 1, log),
 				// Initialize edition cache to prevent nil pointer dereference
 				editionCache: cache.WithTTL[int, *models.Edition](
 					cache.NewMemoryCache[int, *models.Edition](log),

--- a/internal/api/hardcover/people_test.go
+++ b/internal/api/hardcover/people_test.go
@@ -174,7 +174,7 @@ func TestClient_SearchPeople(t *testing.T) {
 				baseURL:     ts.URL,
 				httpClient:  http.DefaultClient,
 				logger:      log,
-				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 1, 10, log), // Fast rate limiting for tests
+				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 10, log), // Fast rate limiting for tests
 				maxRetries:  3,
 				retryDelay:  time.Millisecond, // Fast retry for tests
 			}

--- a/internal/api/hardcover/reading_progress_test.go
+++ b/internal/api/hardcover/reading_progress_test.go
@@ -183,7 +183,7 @@ func TestClient_InsertUserBookRead(t *testing.T) {
 				authToken:        "test-token",
 				httpClient:       server.Client(),
 				logger:           log,
-				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, log),
 				maxRetries:       3,
 				retryDelay:       10*time.Millisecond,
 				userBookIDCache:  cache.NewMemoryCache[int, int](log),
@@ -278,7 +278,7 @@ func TestClient_InsertUserBookRead_IncludesProgressSeconds(t *testing.T) {
 		authToken:       "test-token",
 		httpClient:      server.Client(),
 		logger:          log,
-		rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+		rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 1, log),
 		maxRetries:      3,
 		retryDelay:      10 * time.Millisecond,
 		userBookIDCache: cache.NewMemoryCache[int, int](log),
@@ -465,7 +465,7 @@ func TestClient_UpdateUserBookRead(t *testing.T) {
 				authToken:        "test-token",
 				httpClient:       server.Client(),
 				logger:           log,
-				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, log),
 				maxRetries:       3,
 				retryDelay:       10*time.Millisecond,
 				userBookIDCache:  cache.NewMemoryCache[int, int](log),
@@ -687,7 +687,7 @@ func TestClient_GetUserBookReads(t *testing.T) {
 				authToken:        "test-token",
 				httpClient:       server.Client(),
 				logger:           log,
-				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, 1, log),
+				rateLimiter:      util.NewRateLimiter(10*time.Millisecond, 1, log),
 				maxRetries:       3,
 				retryDelay:       10*time.Millisecond,
 				userBookIDCache:  cache.NewMemoryCache[int, int](log),
@@ -803,7 +803,7 @@ func TestClient_CheckExistingFinishedRead(t *testing.T) {
 				authToken:   "test-token",
 				httpClient:  server.Client(),
 				logger:      log,
-				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 1, 10, log), // Fast rate limiting for tests
+				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 10, log), // Fast rate limiting for tests
 				maxRetries:  3,
 				retryDelay:  time.Millisecond,
 			}
@@ -960,7 +960,7 @@ func TestClient_GetGoogleUploadCredentials(t *testing.T) {
 				authToken:   "test-token",
 				httpClient:  server.Client(),
 				logger:      log,
-				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 1, 10, log), // Fast rate limiting for tests
+				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 10, log), // Fast rate limiting for tests
 				maxRetries:  3,
 				retryDelay:  time.Millisecond,
 			}

--- a/internal/api/hardcover/search_extended_test.go
+++ b/internal/api/hardcover/search_extended_test.go
@@ -397,6 +397,23 @@ func TestClient_SearchPublishers(t *testing.T) {
 	}
 }
 
+func TestClient_SearchPublishersAdmitsRateLimiterOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, `{"data":{"publishers":[{"id":123,"name":"Test Publisher"}]}}`); err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := CreateTestClient(server)
+	publishers, err := client.SearchPublishers(context.Background(), "Test Publisher", 1)
+
+	require.NoError(t, err)
+	require.Len(t, publishers, 1)
+	assert.Equal(t, uint64(1), client.rateLimiter.GetMetrics().Requests)
+}
+
 func TestClient_GetPersonByID(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/api/hardcover/test_helper.go
+++ b/internal/api/hardcover/test_helper.go
@@ -36,7 +36,7 @@ func CreateTestClient(server *httptest.Server) *Client {
 			},
 		},
 		logger:          log,
-		rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 5, 10, log),
+		rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 10, log),
 		maxRetries:      0, // Disable retries in tests to reduce noise
 		retryDelay:      time.Millisecond,
 		userBookIDCache: cache.NewMemoryCache[int, int](log),

--- a/internal/api/hardcover/update_user_book_status_test.go
+++ b/internal/api/hardcover/update_user_book_status_test.go
@@ -174,7 +174,7 @@ func TestClient_UpdateUserBookStatus(t *testing.T) {
 				logger:      log,
 				maxRetries:  3,
 				retryDelay:  time.Millisecond * 100,
-				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 5, 10, log), // Initialize rate limiter with reasonable test values
+				rateLimiter: util.NewRateLimiter(10*time.Millisecond, 10, log), // Initialize rate limiter with reasonable test values
 			}
 			
 			// Prepare the expected input that the server should receive

--- a/internal/api/hardcover/user_book_management_test.go
+++ b/internal/api/hardcover/user_book_management_test.go
@@ -80,7 +80,7 @@ Format: "json",
 				authToken:       "test-token",
 				httpClient:      server.Client(),
 				logger:          log,
-				rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 1, 10, log), // Fast rate limiting for tests
+				rateLimiter:     util.NewRateLimiter(10*time.Millisecond, 10, log), // Fast rate limiting for tests
 				userBookIDCache: cache.NewMemoryCache[int, int](log),
 				userCache:       cache.NewMemoryCache[string, any](log),
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,8 +66,6 @@ type Config struct {
 	RateLimit struct {
 		// Rate is the minimum time between requests (e.g., 2s for 1 request per 2 seconds)
 		Rate time.Duration `yaml:"rate" env:"RATE_LIMIT_RATE"`
-		// Burst is the maximum number of requests that can be made in a burst
-		Burst int `yaml:"burst" env:"RATE_LIMIT_BURST"`
 		// MaxConcurrent is the maximum number of concurrent requests
 		MaxConcurrent int `yaml:"max_concurrent" env:"RATE_LIMIT_MAX_CONCURRENT"`
 	} `yaml:"rate_limit"`
@@ -231,7 +229,6 @@ func DefaultConfig() *Config {
 
 	// Default rate limiting (Hardcover API limit: 30 requests per minute)
 	cfg.RateLimit.Rate = 2 * time.Second
-	cfg.RateLimit.Burst = 1
 	cfg.RateLimit.MaxConcurrent = 1
 
 	// Database defaults
@@ -333,8 +330,8 @@ func Load(configPath string) (*Config, error) {
 		cfg.Sync.ProcessUnreadBooks, cfg.Sync.SyncOwned, cfg.Sync.DryRun,
 		cfg.Sync.SingleUserMode, cfg.Sync.SingleUserUsername, cfg.Sync.TestBookFilter,
 		cfg.Sync.TestBookLimit, cfg.Sync.IncludeEbooks)
-	fmt.Printf("Rate Limiting:\n  rate: %s\n  burst: %d\n  max_concurrent: %d\n",
-		cfg.RateLimit.Rate, cfg.RateLimit.Burst, cfg.RateLimit.MaxConcurrent)
+	fmt.Printf("Rate Limiting:\n  rate: %s\n  max_concurrent: %d\n",
+		cfg.RateLimit.Rate, cfg.RateLimit.MaxConcurrent)
 	fmt.Printf("Logging:\n  level: %s\n  format: %s\n", 
 		cfg.Logging.Level, cfg.Logging.Format)
 	fmt.Printf("Database:\n  type: %s\n  path: %s\n", 

--- a/internal/multiuser/service.go
+++ b/internal/multiuser/service.go
@@ -325,9 +325,6 @@ func (s *MultiUserService) performSync(ctx context.Context, profileID string, pr
         if s.globalConfig.RateLimit.Rate > 0 {
             hcCfg.RateLimit = s.globalConfig.RateLimit.Rate
         }
-        if s.globalConfig.RateLimit.Burst > 0 {
-            hcCfg.Burst = s.globalConfig.RateLimit.Burst
-        }
         if s.globalConfig.RateLimit.MaxConcurrent > 0 {
             hcCfg.MaxConcurrent = s.globalConfig.RateLimit.MaxConcurrent
         }
@@ -337,7 +334,6 @@ func (s *MultiUserService) performSync(ctx context.Context, profileID string, pr
         "profile_id":     profileID,
         "base_url":       hcCfg.BaseURL,
         "rate_limit":     hcCfg.RateLimit.String(),
-        "burst":          hcCfg.Burst,
         "max_concurrent": hcCfg.MaxConcurrent,
     })
 

--- a/internal/sync/handle_finished_book_test.go
+++ b/internal/sync/handle_finished_book_test.go
@@ -347,7 +347,6 @@ func createTestConfigForTests(syncOwned bool) *config.Config {
 	
 	// Other configuration
 	cfg.RateLimit.Rate = 100 * time.Millisecond
-	cfg.RateLimit.Burst = 10
 	cfg.RateLimit.MaxConcurrent = 5
 	cfg.Logging.Level = "info"
 	cfg.Logging.Format = "console"
@@ -356,7 +355,6 @@ func createTestConfigForTests(syncOwned bool) *config.Config {
 	
 	return cfg
 }
-
 
 
 

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -432,7 +432,6 @@ func createTestConfig(syncOwned bool) *config.Config {
 	
 	// Other configuration
 	cfg.RateLimit.Rate = 100 * time.Millisecond
-	cfg.RateLimit.Burst = 10
 	cfg.RateLimit.MaxConcurrent = 5
 	cfg.Logging.Level = "info"
 	cfg.Logging.Format = "console"

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -279,21 +279,6 @@ func (r *RateLimiter) SetJitterFactor(factor float64) {
 	r.jitterFactor = math.Max(0, math.Min(1, factor)) // Clamp between 0 and 1
 }
 
-// checkBackoff checks if we're in a backoff period and returns the remaining duration
-// Note: Caller must hold at least a read lock on r.mu
-func (r *RateLimiter) checkBackoff() time.Duration {
-	if r.backoffUntil.IsZero() {
-		return 0
-	}
-
-	now := time.Now()
-	if !now.Before(r.backoffUntil) {
-		return 0
-	}
-
-	return r.backoffUntil.Sub(now)
-}
-
 // calculateJitter calculates a jitter duration based on the current rate
 func (r *RateLimiter) calculateJitter() time.Duration {
 	return time.Duration((rand.Float64()*2 - 1) * float64(r.rate) * r.jitterFactor)

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -35,6 +35,8 @@ var (
 	DefaultBurst = 1
 	// DefaultMaxBackoff is the default maximum backoff time (increased for more conservative behavior)
 	DefaultMaxBackoff = 10 * time.Minute
+	// DefaultMaxDailyResetWait bounds authoritative daily quota reset delays.
+	DefaultMaxDailyResetWait = 24 * time.Hour
 	// DefaultBackoffFactor is the default backoff multiplier (increased for more aggressive backoff)
 	DefaultBackoffFactor = 8.0
 	// DefaultJitterFactor is the default jitter factor (0.0 to 1.0) (increased for better distribution)
@@ -625,15 +627,14 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 		}
 
 		if r.dailyRemaining <= 0 && reset[dailyName] > 0 {
-			pause := time.Duration(reset[dailyName]) * time.Second
-			retryInterval := r.applyRetryAfter(pause)
+			resetSeconds := reset[dailyName]
+			appliedPause := r.applyDailyResetWait(resetSeconds)
 			r.drainBucket()
-			r.logger.Warn("Daily rate limit exhausted, retrying periodically until reset", map[string]interface{}{
+			r.logger.Warn("Daily rate limit exhausted, pausing until reset", map[string]interface{}{
 				"component":       "rate_limiter",
 				"daily_remaining": r.dailyRemaining,
 				"daily_limit":     r.dailyLimit,
-				"reset_in":        pause.String(),
-				"retry_interval":  retryInterval.String(),
+				"pause":           appliedPause.String(),
 			})
 		} else if r.dailyRemaining > 0 && r.dailyLimit > 0 {
 			pct := float64(r.dailyRemaining) / float64(r.dailyLimit) * 100
@@ -817,11 +818,28 @@ func (r *RateLimiter) exponentialBackoff(baseBackoff time.Duration) time.Duratio
 
 // applyRetryAfter installs an exact, temporary server-directed pause.
 func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
+	return r.applyPause(delay, r.maxBackoff)
+}
+
+// applyDailyResetWait pauses admission until an authoritative daily quota reset,
+// bounded independently from shorter retry backoffs.
+func (r *RateLimiter) applyDailyResetWait(resetSeconds int) time.Duration {
+	if resetSeconds <= 0 {
+		return 0
+	}
+	maxSeconds := int(DefaultMaxDailyResetWait / time.Second)
+	if resetSeconds > maxSeconds {
+		resetSeconds = maxSeconds
+	}
+	return r.applyPause(time.Duration(resetSeconds)*time.Second, DefaultMaxDailyResetWait)
+}
+
+func (r *RateLimiter) applyPause(delay, maxDelay time.Duration) time.Duration {
 	if delay <= 0 {
 		return 0
 	}
-	if delay > r.maxBackoff {
-		delay = r.maxBackoff
+	if delay > maxDelay {
+		delay = maxDelay
 	}
 	until := time.Now().Add(delay)
 	if until.After(r.backoffUntil) {

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -46,17 +46,17 @@ var (
 
 // RateLimiter implements a token bucket rate limiter with dynamic rate adjustment
 type RateLimiter struct {
-	mu             sync.RWMutex
-	last           time.Time
-	rate           time.Duration
-	minRate        time.Duration
-	maxRate        time.Duration
-	tokens         int
-	maxTokens      int
-	lastRateDrop   time.Time
-	backoffUntil   time.Time
-	backoffFactor  float64
-	jitterFactor   float64
+	mu            sync.RWMutex
+	last          time.Time
+	rate          time.Duration
+	minRate       time.Duration
+	maxRate       time.Duration
+	tokens        int
+	maxTokens     int
+	lastRateDrop  time.Time
+	backoffUntil  time.Time
+	backoffFactor float64
+	jitterFactor  float64
 
 	// Daily limit tracking from IETF RateLimit headers
 	dailyRemaining int
@@ -64,8 +64,8 @@ type RateLimiter struct {
 	dailyResetSec  int
 
 	// Concurrency control
-	maxConcurrent  int32         // Maximum number of concurrent requests
-	semaphore      chan struct{} // Buffered channel used as a semaphore
+	maxConcurrent int32         // Maximum number of concurrent admission waiters
+	semaphore     chan struct{} // Buffered channel used as a semaphore
 
 	// Metrics
 	metrics Metrics
@@ -126,7 +126,7 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 		last:          now,
 		rate:          rate,
 		minRate:       rate,
-		maxRate:       10 * time.Minute, // Maximum time between requests
+		maxRate:       DefaultMaxBackoff, // Maximum time between requests
 		tokens:        burst,
 		maxTokens:     burst,
 		lastRateDrop:  now,
@@ -153,49 +153,11 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 
 // Wait blocks until a token is available or the context is cancelled
 func (r *RateLimiter) Wait(ctx context.Context) error {
-	// Check if we're in a backoff period first
-	r.mu.RLock()
-	backoffRemaining := r.checkBackoff()
-	r.mu.RUnlock()
-
-	if backoffRemaining > 0 {
-		r.logger.Debug("Rate limiter in backoff period", map[string]interface{}{
-			"backoff_remaining": backoffRemaining.String(),
-		})
-
-		// If we have a context with deadline, check if we can wait that long
-		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < backoffRemaining {
-			r.logger.Debug("Context deadline too soon for backoff", map[string]interface{}{
-				"deadline":           deadline,
-				"backoff_remaining": backoffRemaining,
-			})
-			// Return the context error to ensure proper error wrapping
-			if ctx.Err() == nil {
-				return context.DeadlineExceeded
-			}
-			return ctx.Err()
-		}
-
-		// Wait for the backoff period or context cancellation
-		timer := time.NewTimer(backoffRemaining)
-		defer timer.Stop()
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timer.C:
-			// Continue with the request after backoff
-		}
-	}
-
-	// First handle concurrency limiting if enabled
+	// Limit the number of goroutines concurrently waiting for admission.
 	if r.maxConcurrent > 0 {
-		// Try to acquire a token from the semaphore channel (will block if empty)
 		select {
 		case <-r.semaphore:
-			// Successfully acquired a token, make sure to release it when done
 			defer func() {
-				// Release the token by sending it back to the channel
 				r.semaphore <- struct{}{}
 			}()
 		case <-ctx.Done():
@@ -203,51 +165,43 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 		}
 	}
 
-	// Now handle rate limiting
 	r.mu.Lock()
-
-	// Update metrics
 	atomic.AddUint64(&r.metrics.Requests, 1)
-
 	now := time.Now()
-
-	// Calculate time since last request
-	timeSinceLast := now.Sub(r.last)
-
-	// If we haven't waited long enough since the last request, wait the remaining time
-	if timeSinceLast < r.rate {
-		waitTime := r.rate - timeSinceLast
-		
-		// Update the last request time before releasing the lock
-		// This ensures proper rate limiting even if we get preempted
-		r.last = r.last.Add(waitTime)
-
-		// Release the lock while we wait
-		r.mu.Unlock()
-
-		// Wait for the required time or context cancellation
-		timer := time.NewTimer(waitTime)
-		defer timer.Stop()
-
-		select {
-		case <-ctx.Done():
-			// If context is canceled, we need to re-acquire the lock to update state
-			r.mu.Lock()
-			// Update the last request time to now to prevent other goroutines from
-			// immediately proceeding if they were waiting on this one
-			r.last = time.Now()
-			r.mu.Unlock()
-			return ctx.Err()
-		case <-timer.C:
-			// No need to update state here since we already did it before waiting
-			return nil
-		}
+	readyAt := now
+	if r.backoffUntil.After(readyAt) {
+		readyAt = r.backoffUntil
+		r.logger.Debug("Rate limiter in backoff period", map[string]interface{}{
+			"backoff_remaining": readyAt.Sub(now).String(),
+		})
+	}
+	if nextRequestAt := r.last.Add(r.rate); nextRequestAt.After(readyAt) {
+		readyAt = nextRequestAt
 	}
 
-	// If we get here, we don't need to wait
-	r.last = now
+	// Reserve the request's admission time while holding the lock. Every
+	// concurrent waiter therefore receives a distinct slot at least rate apart.
+	r.last = readyAt
 	r.mu.Unlock()
-	return nil
+
+	waitTime := time.Until(readyAt)
+	if waitTime <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(waitTime)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		// Only roll back the reservation when no later waiter depends on it.
+		r.mu.Lock()
+		if r.last.Equal(readyAt) {
+			r.last = time.Now()
+		}
+		r.mu.Unlock()
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // OnRateLimit is called when a rate limit is encountered
@@ -264,41 +218,23 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 		r.metrics.RetryAfter++
 	}
 
-	// If we have a retry-after header, use that as the base for backoff
-	baseBackoff := r.rate
+	// Retry-After is an authoritative server delay. Honor it directly rather
+	// than multiplying it again as an exponential backoff input.
 	if retryAfter > 0 {
-		baseBackoff = retryAfter
-		// Add a small buffer to the retry-after to be extra safe
-		baseBackoff = time.Duration(float64(baseBackoff) * 1.2)
+		backoff := r.applyRetryAfter(retryAfter)
+		r.logger.Warn("Rate limit backoff", map[string]interface{}{
+			"retryAfter":   retryAfter.String(),
+			"backoffUntil": r.backoffUntil.Format(time.RFC3339),
+		})
+		return backoff
 	}
 
-	// Calculate exponential backoff with the configured factor
-	backoff := time.Duration(float64(baseBackoff) * r.backoffFactor)
-
-	// Add jitter to prevent thundering herd (using the full jitter range)
-	jitter := time.Duration(rand.Float64() * float64(backoff) * r.jitterFactor)
-	if rand.Float64() < 0.5 {
-		backoff -= jitter
-	} else {
-		backoff += jitter
-	}
-
-	// Ensure backoff is within bounds
-	if backoff < r.minRate {
-		backoff = r.minRate
-	}
-	if backoff > r.maxRate {
-		backoff = r.maxRate
-	}
-
-	// Update rate to the new backoff value
-	r.rate = backoff
-
-	// Reset tokens to prevent burst after backoff
-	r.tokens = 1
-
-	// Set backoff until time
+	// Without server guidance, use exponential backoff. A subsequent healthy
+	// rate-limit response restores the configured rate.
+	backoff := r.exponentialBackoff(r.rate)
+	r.setRate(backoff)
 	r.backoffUntil = now.Add(backoff)
+	r.drainBucket()
 
 	// Log the rate limit event with detailed information
 	r.logger.Warn("Rate limit backoff", map[string]interface{}{
@@ -312,15 +248,13 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 	return backoff
 }
 
-// ResetRate resets the rate limiter to its default rate and backoff factor
+// ResetRate restores the configured rate and default backoff settings.
 func (r *RateLimiter) ResetRate() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Reset the rate to the default rate
-	r.rate = DefaultRate
-	// Also update minRate to match the default rate
-	r.minRate = DefaultRate
+	// Reset to the rate configured for this limiter, not the package default.
+	r.rate = r.minRate
 	// Reset the backoff period
 	r.backoffUntil = time.Time{}
 	// Reset the last rate drop time
@@ -378,8 +312,7 @@ func (r *RateLimiter) checkBackoff() time.Duration {
 	}
 
 	now := time.Now()
-	if now.After(r.backoffUntil) {
-		r.backoffUntil = time.Time{}
+	if !now.Before(r.backoffUntil) {
 		return 0
 	}
 
@@ -486,7 +419,7 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 				logFields["url"] = resp.Request.URL.String()
 			}
 			r.logger.Warn("Rate limit error with retry-after header", logFields)
-			r.applyBackoff(duration)
+			r.applyRetryAfter(duration)
 			r.drainBucket()
 			return
 		}
@@ -495,6 +428,25 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 	// Try IETF RateLimit headers first (e.g. "Free";r=8;t=42, "daily";r=4231;t=51234).
 	if iefRemaining, iefReset := r.parseIETFRateLimit(resp.Header); len(iefRemaining) > 0 {
 		r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
+		return
+	}
+
+	// A bare 429 has no server guidance to apply, so preserve the current rate
+	// and build exponential backoff from it. Processing an empty legacy header
+	// set first would reset the rate and prevent repeated 429s from escalating.
+	if resp.StatusCode == http.StatusTooManyRequests &&
+		resp.Header.Get("X-RateLimit-Remaining") == "" &&
+		resp.Header.Get("X-RateLimit-Reset") == "" {
+		backoff := r.exponentialBackoff(r.rate)
+		r.setRate(backoff)
+		r.backoffUntil = time.Now().Add(backoff)
+		r.drainBucket()
+		r.metrics.RateLimited++
+		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
+			"component":     "rate_limiter",
+			"backoff":       backoff.String(),
+			"backoff_until": r.backoffUntil.Format(time.RFC3339),
+		})
 		return
 	}
 
@@ -529,15 +481,16 @@ func (r *RateLimiter) parseIETFRateLimit(h http.Header) (remaining map[string]in
 }
 
 // parseIETFRateLimitPolicy parses the IETF RateLimit-Policy header value.
-// Returns maps from bucket name -> quota/burst.
-func (r *RateLimiter) parseIETFRateLimitPolicy(h http.Header) (quota map[string]int, burst map[string]int) {
+// Returns maps from bucket name to quota, burst allowance, and window seconds.
+func (r *RateLimiter) parseIETFRateLimitPolicy(h http.Header) (quota, burst, window map[string]int) {
 	val := h.Get("RateLimit-Policy")
 	if val == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	quota = make(map[string]int)
 	burst = make(map[string]int)
+	window = make(map[string]int)
 
 	for _, bucket := range rateLimitBuckets(val) {
 		name, params := parseRateLimitBucket(bucket)
@@ -550,8 +503,11 @@ func (r *RateLimiter) parseIETFRateLimitPolicy(h http.Header) (quota map[string]
 		if v, ok := params["burst"]; ok {
 			burst[name] = v
 		}
+		if v, ok := params["w"]; ok {
+			window[name] = v
+		}
 	}
-	return quota, burst
+	return quota, burst, window
 }
 
 // rateLimitBuckets splits a raw IETF RateLimit header into individual bucket entries.
@@ -617,7 +573,8 @@ func parseRateLimitBucket(bucket string) (string, map[string]int) {
 
 // applyIETFHeaders applies rate limit info parsed from IETF-format headers.
 func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.Header) {
-	quota, burst := r.parseIETFRateLimitPolicy(h)
+	quota, burst, window := r.parseIETFRateLimitPolicy(h)
+	desiredRate := r.minRate
 
 	// Update daily tracking.
 	dailyName := findBucketName(remaining, "daily")
@@ -630,18 +587,32 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 			r.dailyResetSec = t
 		}
 
-		if r.dailyRemaining > 0 && r.dailyLimit > 0 {
+		if r.dailyRemaining <= 0 && reset[dailyName] > 0 {
+			pause := time.Duration(reset[dailyName]) * time.Second
+			r.logger.Warn("Daily rate limit exhausted, pausing", map[string]interface{}{
+				"component":       "rate_limiter",
+				"daily_remaining": r.dailyRemaining,
+				"daily_limit":     r.dailyLimit,
+				"pause":           pause.String(),
+			})
+			r.applyRetryAfter(pause)
+			r.drainBucket()
+		} else if r.dailyRemaining > 0 && r.dailyLimit > 0 {
 			pct := float64(r.dailyRemaining) / float64(r.dailyLimit) * 100
-			if pct < 1.0 && time.Now().After(r.backoffUntil) {
-				backoff := max(DefaultRate*10, r.rate)
+			if pct < 1.0 {
+				recoveryWindow := time.Duration(reset[dailyName]) * time.Second
+				if recoveryWindow > 0 {
+					desiredRate = max(desiredRate, recoveryWindow/time.Duration(r.dailyRemaining))
+				} else {
+					desiredRate = max(desiredRate, r.minRate*2)
+				}
 				r.logger.Warn("Daily rate limit exhausted, slowing down", map[string]interface{}{
 					"component":       "rate_limiter",
 					"daily_remaining": r.dailyRemaining,
 					"daily_limit":     r.dailyLimit,
 					"remaining_pct":   fmt.Sprintf("%.1f%%", pct),
-					"new_rate":        backoff.String(),
+					"new_rate":        desiredRate.String(),
 				})
-				r.applyBackoff(backoff)
 			} else if pct < 5.0 {
 				r.logger.Warn("Daily rate limit approaching, being conservative", map[string]interface{}{
 					"component":       "rate_limiter",
@@ -653,10 +624,15 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 		}
 	}
 
-	// Apply per-minute rate limiting.
+	// Apply per-window rate limiting. The policy quota/window describes the
+	// sustainable request interval; burst is not a requests-per-minute quota.
 	for name, rem := range remaining {
 		if name == dailyName {
 			continue
+		}
+		if q := quota[name]; q > 0 && window[name] > 0 {
+			sustainableRate := time.Duration(window[name]) * time.Second / time.Duration(q)
+			desiredRate = max(desiredRate, sustainableRate)
 		}
 		b := 0
 		if v, ok := burst[name]; ok {
@@ -664,26 +640,29 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 		}
 		if rem <= 1 {
 			resetSec := reset[name]
-			var backoff time.Duration
+			var pause time.Duration
 			if resetSec > 0 {
-				backoff = time.Duration(float64(resetSec)*1.2) * time.Second
-			} else if b > 0 {
-				backoff = time.Duration(60/b) * time.Second
-			} else {
-				backoff = r.rate * 2
+				pause = time.Duration(float64(resetSec)*1.2) * time.Second
 			}
-			r.logger.Warn("Per-minute rate limit nearly exhausted, backing off", map[string]interface{}{
-				"component":   "rate_limiter",
-				"bucket":      name,
-				"remaining":   rem,
-				"burst":       b,
-				"reset_in_s":  reset[name],
-				"backoff":     backoff.String(),
-			})
-			r.applyBackoff(backoff)
-			r.drainBucket()
+			if pause > 0 || desiredRate > r.minRate {
+				r.logger.Info("Rate limit window nearly exhausted, slowing down", map[string]interface{}{
+					"component":  "rate_limiter",
+					"bucket":     name,
+					"remaining":  rem,
+					"burst":      b,
+					"reset_in_s": reset[name],
+					"pause":      pause.String(),
+					"new_rate":   desiredRate.String(),
+				})
+			}
+			if pause > 0 {
+				r.applyRetryAfter(pause)
+				r.drainBucket()
+			}
 		}
 	}
+
+	r.setRate(desiredRate)
 }
 
 // findBucketName returns the key in the map whose lowercase form matches target.
@@ -701,6 +680,7 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	limit := h.Get("X-RateLimit-Limit")
 	remaining := h.Get("X-RateLimit-Remaining")
 	reset := h.Get("X-RateLimit-Reset")
+	desiredRate := r.minRate
 
 	if remaining != "" {
 		rem, err := strconv.Atoi(remaining)
@@ -711,43 +691,49 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 			}
 			if totalLimit > 0 {
 				remainingPct := (float64(rem) / float64(totalLimit)) * 100
-				if remainingPct < 20.0 && time.Now().After(r.backoffUntil) {
-					backoff := time.Duration(float64(r.rate) * (1.0 + (100.0-remainingPct)/10.0))
-					r.logger.Warn("Approaching rate limit (legacy headers), being more conservative", map[string]interface{}{
+				if rem > 0 && remainingPct < 20.0 {
+					if resetAt, ok := parseUnixReset(reset); ok {
+						desiredRate = max(desiredRate, time.Until(resetAt)/time.Duration(rem))
+					} else {
+						desiredRate = max(desiredRate, r.minRate*2)
+					}
+					r.logger.Info("Approaching rate limit (legacy headers), being more conservative", map[string]interface{}{
 						"component":     "rate_limiter",
 						"remaining":     remaining,
 						"limit":         limit,
 						"remaining_pct": remainingPct,
+						"new_rate":      desiredRate.String(),
 					})
-					r.applyBackoff(backoff)
 				}
 			}
-			if rem <= 1 {
-				var backoff time.Duration
-				if reset != "" {
-					if ts, err := strconv.ParseInt(reset, 10, 64); err == nil {
-						backoff = time.Duration(float64(time.Until(time.Unix(ts, 0))) * 1.2)
-					}
+			if rem <= 0 {
+				pause := time.Duration(0)
+				if resetAt, ok := parseUnixReset(reset); ok {
+					pause = time.Until(resetAt)
 				}
-				if backoff <= 0 {
-					backoff = r.rate * 2
+				if pause <= 0 {
+					desiredRate = max(desiredRate, r.minRate*2)
 				}
 				r.logger.Warn("Rate limit reached (legacy headers), backing off", map[string]interface{}{
 					"component": "rate_limiter",
-					"backoff":   backoff.String(),
+					"backoff":   pause.String(),
+					"new_rate":  desiredRate.String(),
 				})
-				r.applyBackoff(backoff)
-				r.drainBucket()
+				if pause > 0 {
+					r.applyRetryAfter(pause)
+					r.drainBucket()
+				}
 			}
 		}
 	}
+	r.setRate(desiredRate)
 
 	if reset != "" {
 		ts, err := strconv.ParseInt(reset, 10, 64)
 		if err == nil {
 			resetTime := time.Unix(ts, 0)
 			if resetTime.After(time.Now()) {
-				r.logger.Info("Rate limit will reset, scheduling next request", map[string]interface{}{
+				r.logger.Debug("Rate limit will reset, scheduling next request", map[string]interface{}{
 					"component": "rate_limiter",
 					"reset_in":  time.Until(resetTime).String(),
 				})
@@ -756,8 +742,20 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	}
 }
 
-// applyBackoff adjusts the rate and sets a backoff interval.
-func (r *RateLimiter) applyBackoff(baseBackoff time.Duration) {
+func parseUnixReset(value string) (time.Time, bool) {
+	if value == "" {
+		return time.Time{}, false
+	}
+	ts, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	resetAt := time.Unix(ts, 0)
+	return resetAt, resetAt.After(time.Now())
+}
+
+// exponentialBackoff calculates a bounded client-selected retry delay.
+func (r *RateLimiter) exponentialBackoff(baseBackoff time.Duration) time.Duration {
 	backoff := time.Duration(float64(baseBackoff) * r.backoffFactor)
 	jitter := time.Duration(rand.Float64() * float64(backoff) * r.jitterFactor)
 	if rand.Float64() < 0.5 {
@@ -771,8 +769,49 @@ func (r *RateLimiter) applyBackoff(baseBackoff time.Duration) {
 	if backoff > r.maxRate {
 		backoff = r.maxRate
 	}
-	r.rate = backoff
-	r.backoffUntil = time.Now().Add(backoff)
+	return backoff
+}
+
+// applyRetryAfter installs an exact, temporary server-directed pause.
+func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	if delay > r.maxRate {
+		delay = r.maxRate
+	}
+	until := time.Now().Add(delay)
+	if until.After(r.backoffUntil) {
+		r.backoffUntil = until
+		r.metrics.BackoffEvents++
+	}
+	return delay
+}
+
+// setRate updates the steady request interval. Header processing calls this on
+// every response, so authoritative healthy quota data restores the configured
+// rate after a temporary slowdown.
+func (r *RateLimiter) setRate(rate time.Duration) {
+	if rate < r.minRate {
+		rate = r.minRate
+	}
+	if rate > r.maxRate {
+		rate = r.maxRate
+	}
+	if rate == r.rate {
+		return
+	}
+	if rate > r.rate {
+		r.metrics.BackoffEvents++
+	} else {
+		r.logger.Info("Rate limiter pacing recovered", map[string]interface{}{
+			"component":     "rate_limiter",
+			"previous_rate": r.rate.String(),
+			"new_rate":      rate.String(),
+		})
+	}
+	r.rate = rate
+	r.lastRateDrop = time.Now()
 }
 
 // drainBucket empties the token bucket to prevent burst after backoff.

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -63,8 +63,7 @@ type RateLimiter struct {
 	dailyResetSec  int
 
 	// Concurrency control
-	maxConcurrent int32         // Maximum number of concurrent admission waiters
-	semaphore     chan struct{} // Buffered channel used as a semaphore
+	semaphore chan struct{} // Buffered channel used as a semaphore
 
 	// Metrics
 	metrics Metrics
@@ -132,7 +131,6 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 		backoffFactor:   DefaultBackoffFactor,
 		jitterFactor:    DefaultJitterFactor,
 		scheduleChanged: make(chan struct{}),
-		maxConcurrent:   int32(maxConcurrent),
 		semaphore:       make(chan struct{}, maxConcurrent),
 		metrics:         Metrics{},
 		logger:          log,
@@ -142,7 +140,7 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 	// Each token is represented by sending a value to the channel.
 	// To acquire a token, receive from the channel.
 	// To release a token, send to the channel.
-	for i := 0; i < int(rl.maxConcurrent); i++ {
+	for i := 0; i < maxConcurrent; i++ {
 		rl.semaphore <- struct{}{}
 	}
 
@@ -152,15 +150,13 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 // Wait blocks until a token is available or the context is cancelled
 func (r *RateLimiter) Wait(ctx context.Context) error {
 	// Limit the number of goroutines concurrently waiting for admission.
-	if r.maxConcurrent > 0 {
-		select {
-		case <-r.semaphore:
-			defer func() {
-				r.semaphore <- struct{}{}
-			}()
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	select {
+	case <-r.semaphore:
+		defer func() {
+			r.semaphore <- struct{}{}
+		}()
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	r.mu.Lock()

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -176,20 +176,10 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 		timer := time.NewTimer(time.Until(readyAt))
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			stopAndDrainTimer(timer)
 			return ctx.Err()
 		case <-scheduleChanged:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			stopAndDrainTimer(timer)
 			// Recalculate immediately when rate-limit headers change the
 			// steady pace or install/remove a backoff period.
 		case <-timer.C:
@@ -202,8 +192,6 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	now := time.Now()
 
 	// Update metrics
 	r.metrics.RateLimited++
@@ -224,9 +212,7 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 
 	// Without server guidance, use exponential backoff. A subsequent healthy
 	// rate-limit response restores the configured rate.
-	backoff := r.exponentialBackoff(r.rate)
-	r.setRate(backoff)
-	r.setBackoffUntil(now.Add(backoff))
+	backoff := r.applyExponentialBackoff(false)
 
 	// Log the rate limit event with detailed information
 	r.logger.Warn("Rate limit backoff", map[string]interface{}{
@@ -422,13 +408,13 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 	}
 
 	// Try IETF RateLimit headers first (e.g. "Free";r=8;t=42, "daily";r=4231;t=51234).
-	iefRemaining, iefReset := r.parseIETFRateLimit(resp.Header)
+	ietfRemaining, ietfReset := r.parseIETFRateLimit(resp.Header)
 	if resp.StatusCode == http.StatusTooManyRequests {
 		// On a 429, only an exhausted quota with a usable reset is authoritative.
 		// Other IETF or legacy headers may be partial, malformed, or merely
 		// advisory; fall through to the bounded client-selected backoff instead.
-		if hasExhaustedIETFQuota(iefRemaining, iefReset) {
-			r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
+		if hasExhaustedIETFQuota(ietfRemaining, ietfReset) {
+			r.applyIETFHeaders(ietfRemaining, ietfReset, resp.Header)
 			return
 		}
 		if hasExhaustedLegacyQuota(resp.Header) {
@@ -438,12 +424,7 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 
 		// Processing an incomplete legacy header set first would reset the rate
 		// and prevent repeated 429s from escalating.
-		backoff := r.exponentialBackoff(r.rate)
-		r.setRate(backoff)
-		until := time.Now().Add(backoff)
-		if until.After(r.backoffUntil) {
-			r.setBackoffUntil(until)
-		}
+		backoff := r.applyExponentialBackoff(true)
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
 			"component":     "rate_limiter",
 			"backoff":       backoff.String(),
@@ -451,8 +432,8 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		})
 		return
 	}
-	if len(iefRemaining) > 0 {
-		r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
+	if len(ietfRemaining) > 0 {
+		r.applyIETFHeaders(ietfRemaining, ietfReset, resp.Header)
 		return
 	}
 
@@ -798,6 +779,20 @@ func (r *RateLimiter) exponentialBackoff(baseBackoff time.Duration) time.Duratio
 	return backoff
 }
 
+// applyExponentialBackoff increases pacing and installs a client-selected pause.
+// preserveLongerPause keeps an existing authoritative pause when it is longer
+// than the newly calculated fallback backoff.
+func (r *RateLimiter) applyExponentialBackoff(preserveLongerPause bool) time.Duration {
+	backoff := r.exponentialBackoff(r.rate)
+	r.setRate(backoff)
+
+	until := time.Now().Add(backoff)
+	if !preserveLongerPause || until.After(r.backoffUntil) {
+		r.setBackoffUntil(until)
+	}
+	return backoff
+}
+
 // applyRetryAfter installs an exact, temporary server-directed pause.
 func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
 	return r.applyPause(delay, r.maxBackoff)
@@ -865,6 +860,15 @@ func (r *RateLimiter) setBackoffUntil(until time.Time) {
 	}
 	r.backoffUntil = until
 	r.notifyScheduleChanged()
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 // notifyScheduleChanged wakes admission waiters so they can recalculate after

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -132,16 +132,18 @@ func NewRateLimiter(rate time.Duration, maxConcurrent int, log *logger.Logger) *
 	return rl
 }
 
-// Wait blocks until request admission is available or the context is cancelled.
-func (r *RateLimiter) Wait(ctx context.Context) error {
-	// Limit the number of goroutines concurrently waiting for admission.
+// Acquire blocks until request admission is available or the context is
+// cancelled. The returned function releases the concurrent-request permit.
+func (r *RateLimiter) Acquire(ctx context.Context) (func(), error) {
+	// Limit the number of concurrently admitted active requests.
 	select {
 	case <-r.semaphore:
-		defer func() {
-			r.semaphore <- struct{}{}
-		}()
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
+	}
+
+	release := func() {
+		r.semaphore <- struct{}{}
 	}
 
 	r.mu.Lock()
@@ -163,7 +165,7 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 			// waiters re-check this value before they may proceed.
 			r.last = now
 			r.mu.Unlock()
-			return nil
+			return release, nil
 		}
 		scheduleChanged := r.scheduleChanged
 		r.mu.Unlock()
@@ -172,7 +174,8 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			stopAndDrainTimer(timer)
-			return ctx.Err()
+			release()
+			return nil, ctx.Err()
 		case <-scheduleChanged:
 			stopAndDrainTimer(timer)
 			// Recalculate immediately when rate-limit headers change the
@@ -180,6 +183,18 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 		case <-timer.C:
 		}
 	}
+}
+
+// Wait blocks until request admission is available or the context is
+// cancelled. It preserves the legacy admission-only behavior by releasing
+// the concurrent-request permit immediately after admission.
+func (r *RateLimiter) Wait(ctx context.Context) error {
+	release, err := r.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	release()
+	return nil
 }
 
 // OnRateLimit is called when a rate limit is encountered

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -31,8 +31,6 @@ var (
 	ErrRetryAfter = errors.New("retry after")
 	// DefaultRate is the default minimum time between requests (2s = 0.5 req/s)
 	DefaultRate = 2 * time.Second
-	// DefaultBurst is the default burst size (reduced for more conservative behavior)
-	DefaultBurst = 1
 	// DefaultMaxBackoff is the default maximum backoff time (increased for more conservative behavior)
 	DefaultMaxBackoff = 10 * time.Minute
 	// DefaultMaxDailyResetWait bounds authoritative daily quota reset delays.
@@ -45,15 +43,13 @@ var (
 	DefaultMaxConcurrent = 3
 )
 
-// RateLimiter implements a token bucket rate limiter with dynamic rate adjustment
+// RateLimiter implements dynamic request pacing and concurrency control.
 type RateLimiter struct {
 	mu              sync.RWMutex
 	last            time.Time
 	rate            time.Duration
 	minRate         time.Duration
 	maxBackoff      time.Duration
-	tokens          int
-	maxTokens       int
 	backoffUntil    time.Time
 	backoffFactor   float64
 	jitterFactor    float64
@@ -92,18 +88,13 @@ func (r *RateLimiter) DailyLimit() int {
 	return r.dailyLimit
 }
 
-// NewRateLimiter creates a new RateLimiter with the specified rate and burst size
+// NewRateLimiter creates a new RateLimiter with the specified pacing and concurrency limits.
 // rate is the minimum time between requests (e.g., 1*time.Second for 1 request per second)
-// burst is the maximum number of tokens that can be consumed at once
 // maxConcurrent is the maximum number of concurrent requests (0 for DefaultMaxConcurrent)
 // log is the logger to use for rate limit events (can be nil)
-func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Logger) *RateLimiter {
+func NewRateLimiter(rate time.Duration, maxConcurrent int, log *logger.Logger) *RateLimiter {
 	if rate <= 0 {
 		rate = DefaultRate
-	}
-
-	if burst < 1 {
-		burst = 1
 	}
 
 	if maxConcurrent < 1 {
@@ -117,7 +108,6 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 
 	log.Debug("Initializing rate limiter", map[string]interface{}{
 		"rate":          rate,
-		"burst":         burst,
 		"maxConcurrent": maxConcurrent,
 	})
 
@@ -127,8 +117,6 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 		rate:            rate,
 		minRate:         rate,
 		maxBackoff:      DefaultMaxBackoff, // Maximum backoff and pacing interval
-		tokens:          burst,
-		maxTokens:       burst,
 		backoffUntil:    time.Time{},
 		backoffFactor:   DefaultBackoffFactor,
 		jitterFactor:    DefaultJitterFactor,
@@ -239,7 +227,6 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 	backoff := r.exponentialBackoff(r.rate)
 	r.setRate(backoff)
 	r.setBackoffUntil(now.Add(backoff))
-	r.drainBucket()
 
 	// Log the rate limit event with detailed information
 	r.logger.Warn("Rate limit backoff", map[string]interface{}{
@@ -430,7 +417,6 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 			}
 			r.logger.Warn("Rate limit error with retry-after header", logFields)
 			r.applyRetryAfter(duration)
-			r.drainBucket()
 			return
 		}
 	}
@@ -458,7 +444,6 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		if until.After(r.backoffUntil) {
 			r.setBackoffUntil(until)
 		}
-		r.drainBucket()
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
 			"component":     "rate_limiter",
 			"backoff":       backoff.String(),
@@ -629,7 +614,6 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 		if r.dailyRemaining <= 0 && reset[dailyName] > 0 {
 			resetSeconds := reset[dailyName]
 			appliedPause := r.applyDailyResetWait(resetSeconds)
-			r.drainBucket()
 			r.logger.Warn("Daily rate limit exhausted, pausing until reset", map[string]interface{}{
 				"component":       "rate_limiter",
 				"daily_remaining": r.dailyRemaining,
@@ -696,7 +680,6 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 			}
 			if pause > 0 {
 				r.applyRetryAfter(pause)
-				r.drainBucket()
 			}
 		}
 	}
@@ -761,7 +744,6 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 		backoff := time.Duration(0)
 		if pause > 0 {
 			backoff = r.applyRetryAfter(pause)
-			r.drainBucket()
 		}
 		r.logger.Warn("Rate limit reached (legacy headers), backing off", map[string]interface{}{
 			"component": "rate_limiter",
@@ -890,11 +872,6 @@ func (r *RateLimiter) setBackoffUntil(until time.Time) {
 func (r *RateLimiter) notifyScheduleChanged() {
 	close(r.scheduleChanged)
 	r.scheduleChanged = make(chan struct{})
-}
-
-// drainBucket empties the token bucket to prevent burst after backoff.
-func (r *RateLimiter) drainBucket() {
-	r.tokens = 1
 }
 
 // Metrics returns a snapshot of the rate limiter's internal state.

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -117,19 +117,14 @@ func NewRateLimiter(rate time.Duration, maxConcurrent int, log *logger.Logger) *
 		rate:            rate,
 		minRate:         rate,
 		maxBackoff:      DefaultMaxBackoff, // Maximum backoff and pacing interval
-		backoffUntil:    time.Time{},
 		backoffFactor:   DefaultBackoffFactor,
 		jitterFactor:    DefaultJitterFactor,
 		scheduleChanged: make(chan struct{}),
 		semaphore:       make(chan struct{}, maxConcurrent),
-		metrics:         Metrics{},
 		logger:          log,
 	}
 
-	// Initialize the semaphore with maxConcurrent tokens
-	// Each token is represented by sending a value to the channel.
-	// To acquire a token, receive from the channel.
-	// To release a token, send to the channel.
+	// Initialize the semaphore with one slot for each allowed concurrent request.
 	for i := 0; i < maxConcurrent; i++ {
 		rl.semaphore <- struct{}{}
 	}
@@ -137,7 +132,7 @@ func NewRateLimiter(rate time.Duration, maxConcurrent int, log *logger.Logger) *
 	return rl
 }
 
-// Wait blocks until a token is available or the context is cancelled
+// Wait blocks until request admission is available or the context is cancelled.
 func (r *RateLimiter) Wait(ctx context.Context) error {
 	// Limit the number of goroutines concurrently waiting for admission.
 	select {

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/drallgood/audiobookshelf-hardcover-sync/internal/logger"
@@ -46,17 +45,18 @@ var (
 
 // RateLimiter implements a token bucket rate limiter with dynamic rate adjustment
 type RateLimiter struct {
-	mu            sync.RWMutex
-	last          time.Time
-	rate          time.Duration
-	minRate       time.Duration
-	maxRate       time.Duration
-	tokens        int
-	maxTokens     int
-	lastRateDrop  time.Time
-	backoffUntil  time.Time
-	backoffFactor float64
-	jitterFactor  float64
+	mu              sync.RWMutex
+	last            time.Time
+	rate            time.Duration
+	minRate         time.Duration
+	maxRate         time.Duration
+	tokens          int
+	maxTokens       int
+	lastRateDrop    time.Time
+	backoffUntil    time.Time
+	backoffFactor   float64
+	jitterFactor    float64
+	scheduleChanged chan struct{}
 
 	// Daily limit tracking from IETF RateLimit headers
 	dailyRemaining int
@@ -123,20 +123,21 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 
 	now := time.Now()
 	rl := &RateLimiter{
-		last:          now,
-		rate:          rate,
-		minRate:       rate,
-		maxRate:       DefaultMaxBackoff, // Maximum time between requests
-		tokens:        burst,
-		maxTokens:     burst,
-		lastRateDrop:  now,
-		backoffUntil:  time.Time{},
-		backoffFactor: DefaultBackoffFactor,
-		jitterFactor:  DefaultJitterFactor,
-		maxConcurrent: int32(maxConcurrent),
-		semaphore:     make(chan struct{}, maxConcurrent),
-		metrics:       Metrics{},
-		logger:        log,
+		last:            now,
+		rate:            rate,
+		minRate:         rate,
+		maxRate:         DefaultMaxBackoff, // Maximum time between requests
+		tokens:          burst,
+		maxTokens:       burst,
+		lastRateDrop:    now,
+		backoffUntil:    time.Time{},
+		backoffFactor:   DefaultBackoffFactor,
+		jitterFactor:    DefaultJitterFactor,
+		scheduleChanged: make(chan struct{}),
+		maxConcurrent:   int32(maxConcurrent),
+		semaphore:       make(chan struct{}, maxConcurrent),
+		metrics:         Metrics{},
+		logger:          log,
 	}
 
 	// Initialize the semaphore with maxConcurrent tokens
@@ -166,41 +167,50 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 	}
 
 	r.mu.Lock()
-	atomic.AddUint64(&r.metrics.Requests, 1)
-	now := time.Now()
-	readyAt := now
-	if r.backoffUntil.After(readyAt) {
-		readyAt = r.backoffUntil
-		r.logger.Debug("Rate limiter in backoff period", map[string]interface{}{
-			"backoff_remaining": readyAt.Sub(now).String(),
-		})
-	}
-	if nextRequestAt := r.last.Add(r.rate); nextRequestAt.After(readyAt) {
-		readyAt = nextRequestAt
-	}
-
-	// Reserve the request's admission time while holding the lock. Every
-	// concurrent waiter therefore receives a distinct slot at least rate apart.
-	r.last = readyAt
+	r.metrics.Requests++
 	r.mu.Unlock()
 
-	waitTime := time.Until(readyAt)
-	if waitTime <= 0 {
-		return nil
-	}
-	timer := time.NewTimer(waitTime)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		// Only roll back the reservation when no later waiter depends on it.
+	for {
 		r.mu.Lock()
-		if r.last.Equal(readyAt) {
-			r.last = time.Now()
+		now := time.Now()
+		readyAt := r.last.Add(r.rate)
+		if r.backoffUntil.After(readyAt) {
+			readyAt = r.backoffUntil
+			r.logger.Debug("Rate limiter in backoff period", map[string]interface{}{
+				"backoff_remaining": readyAt.Sub(now).String(),
+			})
 		}
+		if !readyAt.After(now) {
+			// Record actual admission rather than a future reservation. Other
+			// waiters re-check this value before they may proceed.
+			r.last = now
+			r.mu.Unlock()
+			return nil
+		}
+		scheduleChanged := r.scheduleChanged
 		r.mu.Unlock()
-		return ctx.Err()
-	case <-timer.C:
-		return nil
+
+		timer := time.NewTimer(time.Until(readyAt))
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-scheduleChanged:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			// Recalculate immediately when rate-limit headers change the
+			// steady pace or install/remove a backoff period.
+		case <-timer.C:
+		}
 	}
 }
 
@@ -233,7 +243,7 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 	// rate-limit response restores the configured rate.
 	backoff := r.exponentialBackoff(r.rate)
 	r.setRate(backoff)
-	r.backoffUntil = now.Add(backoff)
+	r.setBackoffUntil(now.Add(backoff))
 	r.drainBucket()
 
 	// Log the rate limit event with detailed information
@@ -253,6 +263,7 @@ func (r *RateLimiter) ResetRate() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	scheduleChanged := r.rate != r.minRate || !r.backoffUntil.IsZero()
 	// Reset to the rate configured for this limiter, not the package default.
 	r.rate = r.minRate
 	// Reset the backoff period
@@ -263,6 +274,9 @@ func (r *RateLimiter) ResetRate() {
 	r.backoffFactor = DefaultBackoffFactor
 	// Reset the jitter factor to the default
 	r.jitterFactor = DefaultJitterFactor
+	if scheduleChanged {
+		r.notifyScheduleChanged()
+	}
 
 	r.logger.Debug("Rate limiter reset", map[string]interface{}{
 		"rate":          r.rate,
@@ -439,7 +453,7 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		resp.Header.Get("X-RateLimit-Reset") == "" {
 		backoff := r.exponentialBackoff(r.rate)
 		r.setRate(backoff)
-		r.backoffUntil = time.Now().Add(backoff)
+		r.setBackoffUntil(time.Now().Add(backoff))
 		r.drainBucket()
 		r.metrics.RateLimited++
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
@@ -782,7 +796,7 @@ func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
 	}
 	until := time.Now().Add(delay)
 	if until.After(r.backoffUntil) {
-		r.backoffUntil = until
+		r.setBackoffUntil(until)
 		r.metrics.BackoffEvents++
 	}
 	return delay
@@ -812,6 +826,24 @@ func (r *RateLimiter) setRate(rate time.Duration) {
 	}
 	r.rate = rate
 	r.lastRateDrop = time.Now()
+	r.notifyScheduleChanged()
+}
+
+// setBackoffUntil updates the temporary admission pause. The caller must hold
+// r.mu.
+func (r *RateLimiter) setBackoffUntil(until time.Time) {
+	if until.Equal(r.backoffUntil) {
+		return
+	}
+	r.backoffUntil = until
+	r.notifyScheduleChanged()
+}
+
+// notifyScheduleChanged wakes admission waiters so they can recalculate after
+// a pacing or backoff update. The caller must hold r.mu.
+func (r *RateLimiter) notifyScheduleChanged() {
+	close(r.scheduleChanged)
+	r.scheduleChanged = make(chan struct{})
 }
 
 // drainBucket empties the token bucket to prevent burst after backoff.

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -389,7 +389,15 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		})
 	}
 
-	// Retry-After takes highest priority (server explicitly telling us to wait).
+	// An exhausted daily quota takes precedence over a generic Retry-After so
+	// the longer authoritative daily reset pause is preserved.
+	ietfRemaining, ietfReset := r.parseIETFRateLimit(resp.Header)
+	if resp.StatusCode == http.StatusTooManyRequests && hasExhaustedDailyIETFQuota(ietfRemaining, ietfReset) {
+		r.applyIETFHeaders(ietfRemaining, ietfReset, resp.Header)
+		return
+	}
+
+	// Retry-After takes priority when no exhausted daily quota overrides it.
 	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 		if duration, err := ParseRetryAfter(retryAfter); err == nil && duration > 0 {
 			logFields := map[string]interface{}{"retryAfter": retryAfter, "status": resp.Status}
@@ -403,7 +411,6 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 	}
 
 	// Try IETF RateLimit headers first (e.g. "Free";r=8;t=42, "daily";r=4231;t=51234).
-	ietfRemaining, ietfReset := r.parseIETFRateLimit(resp.Header)
 	if resp.StatusCode == http.StatusTooManyRequests {
 		// On a 429, only an exhausted quota with a usable reset is authoritative.
 		// Other IETF or legacy headers may be partial, malformed, or merely
@@ -443,6 +450,11 @@ func hasExhaustedIETFQuota(remaining, reset map[string]int) bool {
 		}
 	}
 	return false
+}
+
+func hasExhaustedDailyIETFQuota(remaining, reset map[string]int) bool {
+	dailyName := findBucketName(remaining, "daily")
+	return dailyName != "" && remaining[dailyName] <= 0 && reset[dailyName] > 0
 }
 
 func hasExhaustedLegacyQuota(h http.Header) bool {

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -440,17 +440,22 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 	}
 
 	// Try IETF RateLimit headers first (e.g. "Free";r=8;t=42, "daily";r=4231;t=51234).
-	if iefRemaining, iefReset := r.parseIETFRateLimit(resp.Header); len(iefRemaining) > 0 {
-		r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
-		return
-	}
+	iefRemaining, iefReset := r.parseIETFRateLimit(resp.Header)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// On a 429, only an exhausted quota with a usable reset is authoritative.
+		// Other IETF or legacy headers may be partial, malformed, or merely
+		// advisory; fall through to the bounded client-selected backoff instead.
+		if hasExhaustedIETFQuota(iefRemaining, iefReset) {
+			r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
+			return
+		}
+		if hasExhaustedLegacyQuota(resp.Header) {
+			r.applyLegacyHeaders(resp.Header)
+			return
+		}
 
-	// A bare 429 has no server guidance to apply, so preserve the current rate
-	// and build exponential backoff from it. Processing an empty legacy header
-	// set first would reset the rate and prevent repeated 429s from escalating.
-	if resp.StatusCode == http.StatusTooManyRequests &&
-		resp.Header.Get("X-RateLimit-Remaining") == "" &&
-		resp.Header.Get("X-RateLimit-Reset") == "" {
+		// Processing an incomplete legacy header set first would reset the rate
+		// and prevent repeated 429s from escalating.
 		backoff := r.exponentialBackoff(r.rate)
 		r.setRate(backoff)
 		r.setBackoffUntil(time.Now().Add(backoff))
@@ -463,9 +468,31 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		})
 		return
 	}
+	if len(iefRemaining) > 0 {
+		r.applyIETFHeaders(iefRemaining, iefReset, resp.Header)
+		return
+	}
 
 	// Fall back to legacy X-RateLimit-* headers.
 	r.applyLegacyHeaders(resp.Header)
+}
+
+func hasExhaustedIETFQuota(remaining, reset map[string]int) bool {
+	for name, rem := range remaining {
+		if rem <= 0 && reset[name] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExhaustedLegacyQuota(h http.Header) bool {
+	rem, err := strconv.Atoi(h.Get("X-RateLimit-Remaining"))
+	if err != nil || rem > 0 {
+		return false
+	}
+	_, ok := parseUnixReset(h.Get("X-RateLimit-Reset"))
+	return ok
 }
 
 // parseIETFRateLimit parses the IETF RateLimit header value.

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -643,7 +643,7 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 				} else {
 					desiredRate = max(desiredRate, r.minRate*2)
 				}
-				r.logger.Warn("Daily rate limit exhausted, slowing down", map[string]interface{}{
+				r.logger.Warn("Daily rate limit nearly exhausted, slowing down", map[string]interface{}{
 					"component":       "rate_limiter",
 					"daily_remaining": r.dailyRemaining,
 					"daily_limit":     r.dailyLimit,

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -626,14 +626,15 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 
 		if r.dailyRemaining <= 0 && reset[dailyName] > 0 {
 			pause := time.Duration(reset[dailyName]) * time.Second
-			r.logger.Warn("Daily rate limit exhausted, pausing", map[string]interface{}{
+			retryInterval := r.applyRetryAfter(pause)
+			r.drainBucket()
+			r.logger.Warn("Daily rate limit exhausted, retrying periodically until reset", map[string]interface{}{
 				"component":       "rate_limiter",
 				"daily_remaining": r.dailyRemaining,
 				"daily_limit":     r.dailyLimit,
-				"pause":           pause.String(),
+				"reset_in":        pause.String(),
+				"retry_interval":  retryInterval.String(),
 			})
-			r.applyRetryAfter(pause)
-			r.drainBucket()
 		} else if r.dailyRemaining > 0 && r.dailyLimit > 0 {
 			pct := float64(r.dailyRemaining) / float64(r.dailyLimit) * 100
 			if pct < 1.0 {
@@ -717,51 +718,56 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	limit := h.Get("X-RateLimit-Limit")
 	remaining := h.Get("X-RateLimit-Remaining")
 	reset := h.Get("X-RateLimit-Reset")
+	if remaining == "" {
+		return
+	}
+	rem, err := strconv.Atoi(remaining)
+	if err != nil {
+		return
+	}
+
 	desiredRate := r.minRate
 
-	if remaining != "" {
-		rem, err := strconv.Atoi(remaining)
-		if err == nil {
-			totalLimit := 0
-			if limit != "" {
-				totalLimit, _ = strconv.Atoi(limit)
+	totalLimit := 0
+	if limit != "" {
+		totalLimit, _ = strconv.Atoi(limit)
+	}
+	if totalLimit > 0 {
+		remainingPct := (float64(rem) / float64(totalLimit)) * 100
+		if rem > 0 && remainingPct < 20.0 {
+			if resetAt, ok := parseUnixReset(reset); ok {
+				desiredRate = max(desiredRate, time.Until(resetAt)/time.Duration(rem))
+			} else {
+				desiredRate = max(desiredRate, r.minRate*2)
 			}
-			if totalLimit > 0 {
-				remainingPct := (float64(rem) / float64(totalLimit)) * 100
-				if rem > 0 && remainingPct < 20.0 {
-					if resetAt, ok := parseUnixReset(reset); ok {
-						desiredRate = max(desiredRate, time.Until(resetAt)/time.Duration(rem))
-					} else {
-						desiredRate = max(desiredRate, r.minRate*2)
-					}
-					r.logger.Info("Approaching rate limit (legacy headers), being more conservative", map[string]interface{}{
-						"component":     "rate_limiter",
-						"remaining":     remaining,
-						"limit":         limit,
-						"remaining_pct": remainingPct,
-						"new_rate":      desiredRate.String(),
-					})
-				}
-			}
-			if rem <= 0 {
-				pause := time.Duration(0)
-				if resetAt, ok := parseUnixReset(reset); ok {
-					pause = time.Until(resetAt)
-				}
-				if pause <= 0 {
-					desiredRate = max(desiredRate, r.minRate*2)
-				}
-				r.logger.Warn("Rate limit reached (legacy headers), backing off", map[string]interface{}{
-					"component": "rate_limiter",
-					"backoff":   pause.String(),
-					"new_rate":  desiredRate.String(),
-				})
-				if pause > 0 {
-					r.applyRetryAfter(pause)
-					r.drainBucket()
-				}
-			}
+			r.logger.Info("Approaching rate limit (legacy headers), being more conservative", map[string]interface{}{
+				"component":     "rate_limiter",
+				"remaining":     remaining,
+				"limit":         limit,
+				"remaining_pct": remainingPct,
+				"new_rate":      desiredRate.String(),
+			})
 		}
+	}
+	if rem <= 0 {
+		pause := time.Duration(0)
+		if resetAt, ok := parseUnixReset(reset); ok {
+			pause = time.Until(resetAt)
+		}
+		if pause <= 0 {
+			desiredRate = max(desiredRate, r.minRate*2)
+		}
+		backoff := time.Duration(0)
+		if pause > 0 {
+			backoff = r.applyRetryAfter(pause)
+			r.drainBucket()
+		}
+		r.logger.Warn("Rate limit reached (legacy headers), backing off", map[string]interface{}{
+			"component": "rate_limiter",
+			"reset_in":  pause.String(),
+			"backoff":   backoff.String(),
+			"new_rate":  desiredRate.String(),
+		})
 	}
 	r.setRate(desiredRate)
 

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -452,7 +452,10 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		// and prevent repeated 429s from escalating.
 		backoff := r.exponentialBackoff(r.rate)
 		r.setRate(backoff)
-		r.setBackoffUntil(time.Now().Add(backoff))
+		until := time.Now().Add(backoff)
+		if until.After(r.backoffUntil) {
+			r.setBackoffUntil(until)
+		}
 		r.drainBucket()
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
 			"component":     "rate_limiter",

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -185,18 +185,6 @@ func (r *RateLimiter) Acquire(ctx context.Context) (func(), error) {
 	}
 }
 
-// Wait blocks until request admission is available or the context is
-// cancelled. It preserves the legacy admission-only behavior by releasing
-// the concurrent-request permit immediately after admission.
-func (r *RateLimiter) Wait(ctx context.Context) error {
-	release, err := r.Acquire(ctx)
-	if err != nil {
-		return err
-	}
-	release()
-	return nil
-}
-
 // OnRateLimit is called when a rate limit is encountered
 // It increases the delay between requests and returns the time to wait
 func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
@@ -222,7 +210,7 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 
 	// Without server guidance, use exponential backoff. A subsequent healthy
 	// rate-limit response restores the configured rate.
-	backoff := r.applyExponentialBackoff(false)
+	backoff := r.applyExponentialBackoff(true)
 
 	// Log the rate limit event with detailed information
 	r.logger.Warn("Rate limit backoff", map[string]interface{}{
@@ -611,7 +599,7 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 		} else if r.dailyRemaining > 0 && r.dailyLimit > 0 {
 			pct := float64(r.dailyRemaining) / float64(r.dailyLimit) * 100
 			if pct < 1.0 {
-				recoveryWindow := time.Duration(reset[dailyName]) * time.Second
+				recoveryWindow := boundedSecondsDuration(reset[dailyName], 1, DefaultMaxDailyResetWait)
 				if recoveryWindow > 0 {
 					desiredRate = max(desiredRate, recoveryWindow/time.Duration(r.dailyRemaining))
 				} else {
@@ -642,7 +630,7 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 			continue
 		}
 		if q := quota[name]; q > 0 && window[name] > 0 {
-			sustainableRate := time.Duration(window[name]) * time.Second / time.Duration(q)
+			sustainableRate := boundedSecondsRate(window[name], q, r.maxBackoff)
 			desiredRate = max(desiredRate, sustainableRate)
 		}
 		b := 0
@@ -653,7 +641,7 @@ func (r *RateLimiter) applyIETFHeaders(remaining, reset map[string]int, h http.H
 			resetSec := reset[name]
 			var pause time.Duration
 			if resetSec > 0 {
-				pause = time.Duration(float64(resetSec)*1.2) * time.Second
+				pause = boundedSecondsDuration(resetSec, 1.2, r.maxBackoff)
 			}
 			if pause > 0 || desiredRate > r.minRate {
 				r.logger.Info("Rate limit window nearly exhausted, slowing down", map[string]interface{}{
@@ -784,6 +772,41 @@ func (r *RateLimiter) exponentialBackoff(baseBackoff time.Duration) time.Duratio
 		backoff = r.maxBackoff
 	}
 	return backoff
+}
+
+// boundedSecondsDuration converts header-provided seconds to a duration while
+// avoiding overflow during conversion or multiplication. Values at or beyond
+// the bound are conservatively capped at maxDuration.
+func boundedSecondsDuration(seconds int, multiplier float64, maxDuration time.Duration) time.Duration {
+	if seconds <= 0 || multiplier <= 0 || maxDuration <= 0 {
+		return 0
+	}
+	if float64(seconds) >= float64(maxDuration)/float64(time.Second)/multiplier {
+		return maxDuration
+	}
+	return time.Duration(float64(seconds) * multiplier * float64(time.Second))
+}
+
+// boundedSecondsRate computes a sustainable per-request interval from a
+// policy window and quota without multiplying an untrusted window by a
+// duration before division.
+func boundedSecondsRate(windowSeconds, quota int, maxDuration time.Duration) time.Duration {
+	if windowSeconds <= 0 || quota <= 0 || maxDuration <= 0 {
+		return 0
+	}
+	wholeSeconds := windowSeconds / quota
+	if wholeSeconds >= int(maxDuration/time.Second) {
+		return maxDuration
+	}
+
+	interval := time.Duration(wholeSeconds) * time.Second
+	// The remainder is always less than quota, so only the fractional second
+	// needs floating-point conversion; no untrusted value is multiplied first.
+	fraction := time.Duration(float64(windowSeconds%quota) / float64(quota) * float64(time.Second))
+	if interval > maxDuration-fraction {
+		return maxDuration
+	}
+	return interval + fraction
 }
 
 // applyExponentialBackoff increases pacing and installs a client-selected pause.

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -210,7 +210,7 @@ func (r *RateLimiter) OnRateLimit(retryAfter time.Duration) time.Duration {
 
 	// Without server guidance, use exponential backoff. A subsequent healthy
 	// rate-limit response restores the configured rate.
-	backoff := r.applyExponentialBackoff(true)
+	backoff := r.applyExponentialBackoff()
 
 	// Log the rate limit event with detailed information
 	r.logger.Warn("Rate limit backoff", map[string]interface{}{
@@ -414,7 +414,7 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 
 		// Processing an incomplete legacy header set first would reset the rate
 		// and prevent repeated 429s from escalating.
-		backoff := r.applyExponentialBackoff(true)
+		backoff := r.applyExponentialBackoff()
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
 			"component":     "rate_limiter",
 			"backoff":       backoff.String(),
@@ -685,6 +685,7 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	if err != nil {
 		return
 	}
+	resetAt, resetOK := parseUnixReset(reset)
 
 	desiredRate := r.minRate
 
@@ -695,7 +696,7 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	if totalLimit > 0 {
 		remainingPct := (float64(rem) / float64(totalLimit)) * 100
 		if rem > 0 && remainingPct < 20.0 {
-			if resetAt, ok := parseUnixReset(reset); ok {
+			if resetOK {
 				desiredRate = max(desiredRate, time.Until(resetAt)/time.Duration(rem))
 			} else {
 				desiredRate = max(desiredRate, r.minRate*2)
@@ -711,7 +712,7 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	}
 	if rem <= 0 {
 		pause := time.Duration(0)
-		if resetAt, ok := parseUnixReset(reset); ok {
+		if resetOK {
 			pause = time.Until(resetAt)
 		}
 		if pause <= 0 {
@@ -730,17 +731,11 @@ func (r *RateLimiter) applyLegacyHeaders(h http.Header) {
 	}
 	r.setRate(desiredRate)
 
-	if reset != "" {
-		ts, err := strconv.ParseInt(reset, 10, 64)
-		if err == nil {
-			resetTime := time.Unix(ts, 0)
-			if resetTime.After(time.Now()) {
-				r.logger.Debug("Rate limit will reset, scheduling next request", map[string]interface{}{
-					"component": "rate_limiter",
-					"reset_in":  time.Until(resetTime).String(),
-				})
-			}
-		}
+	if resetOK {
+		r.logger.Debug("Rate limit will reset, scheduling next request", map[string]interface{}{
+			"component": "rate_limiter",
+			"reset_in":  time.Until(resetAt).String(),
+		})
 	}
 }
 
@@ -809,15 +804,14 @@ func boundedSecondsRate(windowSeconds, quota int, maxDuration time.Duration) tim
 	return interval + fraction
 }
 
-// applyExponentialBackoff increases pacing and installs a client-selected pause.
-// preserveLongerPause keeps an existing authoritative pause when it is longer
-// than the newly calculated fallback backoff.
-func (r *RateLimiter) applyExponentialBackoff(preserveLongerPause bool) time.Duration {
+// applyExponentialBackoff increases pacing and installs a client-selected pause
+// without shortening an existing authoritative pause.
+func (r *RateLimiter) applyExponentialBackoff() time.Duration {
 	backoff := r.exponentialBackoff(r.rate)
 	r.setRate(backoff)
 
 	until := time.Now().Add(backoff)
-	if !preserveLongerPause || until.After(r.backoffUntil) {
+	if until.After(r.backoffUntil) {
 		r.setBackoffUntil(until)
 	}
 	return backoff
@@ -831,14 +825,10 @@ func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
 // applyDailyResetWait pauses admission until an authoritative daily quota reset,
 // bounded independently from shorter retry backoffs.
 func (r *RateLimiter) applyDailyResetWait(resetSeconds int) time.Duration {
-	if resetSeconds <= 0 {
-		return 0
-	}
-	maxSeconds := int(DefaultMaxDailyResetWait / time.Second)
-	if resetSeconds > maxSeconds {
-		resetSeconds = maxSeconds
-	}
-	return r.applyPause(time.Duration(resetSeconds)*time.Second, DefaultMaxDailyResetWait)
+	return r.applyPause(
+		boundedSecondsDuration(resetSeconds, 1, DefaultMaxDailyResetWait),
+		DefaultMaxDailyResetWait,
+	)
 }
 
 func (r *RateLimiter) applyPause(delay, maxDelay time.Duration) time.Duration {

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -398,6 +398,9 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		r.metrics.RateLimited++
+	}
 
 	// Collect rate-limit headers for debug logging.
 	headers := make(map[string]string)
@@ -451,7 +454,6 @@ func (r *RateLimiter) WithRateLimitHeaders(resp *http.Response) {
 		r.setRate(backoff)
 		r.setBackoffUntil(time.Now().Add(backoff))
 		r.drainBucket()
-		r.metrics.RateLimited++
 		r.logger.Warn("Rate limit response without reset guidance", map[string]interface{}{
 			"component":     "rate_limiter",
 			"backoff":       backoff.String(),

--- a/internal/util/rate_limiter.go
+++ b/internal/util/rate_limiter.go
@@ -49,10 +49,9 @@ type RateLimiter struct {
 	last            time.Time
 	rate            time.Duration
 	minRate         time.Duration
-	maxRate         time.Duration
+	maxBackoff      time.Duration
 	tokens          int
 	maxTokens       int
-	lastRateDrop    time.Time
 	backoffUntil    time.Time
 	backoffFactor   float64
 	jitterFactor    float64
@@ -126,10 +125,9 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 		last:            now,
 		rate:            rate,
 		minRate:         rate,
-		maxRate:         DefaultMaxBackoff, // Maximum time between requests
+		maxBackoff:      DefaultMaxBackoff, // Maximum backoff and pacing interval
 		tokens:          burst,
 		maxTokens:       burst,
-		lastRateDrop:    now,
 		backoffUntil:    time.Time{},
 		backoffFactor:   DefaultBackoffFactor,
 		jitterFactor:    DefaultJitterFactor,
@@ -144,7 +142,6 @@ func NewRateLimiter(rate time.Duration, burst, maxConcurrent int, log *logger.Lo
 	// Each token is represented by sending a value to the channel.
 	// To acquire a token, receive from the channel.
 	// To release a token, send to the channel.
-	rl.semaphore = make(chan struct{}, rl.maxConcurrent)
 	for i := 0; i < int(rl.maxConcurrent); i++ {
 		rl.semaphore <- struct{}{}
 	}
@@ -268,8 +265,6 @@ func (r *RateLimiter) ResetRate() {
 	r.rate = r.minRate
 	// Reset the backoff period
 	r.backoffUntil = time.Time{}
-	// Reset the last rate drop time
-	r.lastRateDrop = time.Now()
 	// Reset the backoff factor to the default
 	r.backoffFactor = DefaultBackoffFactor
 	// Reset the jitter factor to the default
@@ -807,8 +802,8 @@ func (r *RateLimiter) exponentialBackoff(baseBackoff time.Duration) time.Duratio
 	if backoff < r.minRate {
 		backoff = r.minRate
 	}
-	if backoff > r.maxRate {
-		backoff = r.maxRate
+	if backoff > r.maxBackoff {
+		backoff = r.maxBackoff
 	}
 	return backoff
 }
@@ -818,8 +813,8 @@ func (r *RateLimiter) applyRetryAfter(delay time.Duration) time.Duration {
 	if delay <= 0 {
 		return 0
 	}
-	if delay > r.maxRate {
-		delay = r.maxRate
+	if delay > r.maxBackoff {
+		delay = r.maxBackoff
 	}
 	until := time.Now().Add(delay)
 	if until.After(r.backoffUntil) {
@@ -836,8 +831,8 @@ func (r *RateLimiter) setRate(rate time.Duration) {
 	if rate < r.minRate {
 		rate = r.minRate
 	}
-	if rate > r.maxRate {
-		rate = r.maxRate
+	if rate > r.maxBackoff {
+		rate = r.maxBackoff
 	}
 	if rate == r.rate {
 		return
@@ -852,7 +847,6 @@ func (r *RateLimiter) setRate(rate time.Duration) {
 		})
 	}
 	r.rate = rate
-	r.lastRateDrop = time.Now()
 	r.notifyScheduleChanged()
 }
 

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -14,32 +14,28 @@ func TestNewRateLimiter(t *testing.T) {
 	tests := []struct {
 		name          string
 		rate          time.Duration
-		burst         int
 		maxConcurrent int
 	}{
 		{
 			name:          "default values",
 			rate:          0,
-			burst:         0,
 			maxConcurrent: 0,
 		},
 		{
 			name:          "custom values",
 			rate:          time.Second,
-			burst:         5,
 			maxConcurrent: 10,
 		},
 		{
 			name:          "negative rate uses default",
 			rate:          -1 * time.Second,
-			burst:         5,
 			maxConcurrent: 10,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(tt.rate, tt.burst, tt.maxConcurrent, nil)
+			rl := NewRateLimiter(tt.rate, tt.maxConcurrent, nil)
 			defer rl.ResetRate()
 
 			if tt.rate > 0 {
@@ -47,18 +43,12 @@ func TestNewRateLimiter(t *testing.T) {
 			} else {
 				assert.Equal(t, DefaultRate, rl.GetRate())
 			}
-
-			if tt.burst > 0 {
-				assert.Greater(t, rl.maxTokens, 0)
-			} else {
-				assert.Equal(t, DefaultBurst, rl.maxTokens)
-			}
 		})
 	}
 }
 
 func TestRateLimiterConcurrentAccess(t *testing.T) {
-	rl := NewRateLimiter(5*time.Millisecond, 5, 3, nil)
+	rl := NewRateLimiter(5*time.Millisecond, 3, nil)
 	defer rl.ResetRate()
 
 	const totalRequests = 10

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -16,40 +16,29 @@ func TestNewRateLimiter(t *testing.T) {
 		rate          time.Duration
 		burst         int
 		maxConcurrent int
-		expectPanic   bool
 	}{
 		{
 			name:          "default values",
 			rate:          0,
 			burst:         0,
 			maxConcurrent: 0,
-			expectPanic:   false,
 		},
 		{
 			name:          "custom values",
 			rate:          time.Second,
 			burst:         5,
 			maxConcurrent: 10,
-			expectPanic:   false,
 		},
 		{
 			name:          "negative rate uses default",
 			rate:          -1 * time.Second,
 			burst:         5,
 			maxConcurrent: 10,
-			expectPanic:   false, // Negative rate is handled by using default
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.expectPanic {
-				assert.Panics(t, func() {
-					NewRateLimiter(tt.rate, tt.burst, tt.maxConcurrent, nil)
-				}, "Expected panic for invalid values")
-				return
-			}
-
 			rl := NewRateLimiter(tt.rate, tt.burst, tt.maxConcurrent, nil)
 			defer rl.ResetRate()
 

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -75,3 +75,39 @@ func TestRateLimiterConcurrentAccess(t *testing.T) {
 	}
 	assert.Equal(t, uint64(totalRequests), rl.GetMetrics().Requests)
 }
+
+func TestRateLimiterAcquireBlocksUntilRelease(t *testing.T) {
+	rl := NewRateLimiter(time.Nanosecond, 1, nil)
+	firstRelease, err := rl.Acquire(context.Background())
+	require.NoError(t, err)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			firstRelease()
+		}
+	})
+
+	secondResult := make(chan error, 1)
+	go func() {
+		secondRelease, err := rl.Acquire(context.Background())
+		if err == nil {
+			secondRelease()
+		}
+		secondResult <- err
+	}()
+
+	select {
+	case err := <-secondResult:
+		t.Fatalf("second admission completed while first permit was held: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	firstRelease()
+	released = true
+	select {
+	case err := <-secondResult:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("second admission did not complete after first permit was released")
+	}
+}

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -63,7 +63,11 @@ func TestRateLimiterConcurrentAccess(t *testing.T) {
 			<-startCh
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
-			errCh <- rl.Wait(ctx)
+			release, err := rl.Acquire(ctx)
+			if err == nil {
+				release()
+			}
+			errCh <- err
 		}()
 	}
 

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -147,141 +146,33 @@ func TestNewRateLimiter(t *testing.T) {
 }
 
 func TestRateLimiterConcurrentAccess(t *testing.T) {
-	// Create a test logger
 	log, _ := newTestLogger()
-	log.Info("Starting TestRateLimiterConcurrentAccess")
-	
-	// Set maxConcurrent to 3 to make it easier to hit the limit
-	maxConcurrent := 3
-	rl := NewRateLimiter(10*time.Millisecond, 5, maxConcurrent, log)
+	rl := NewRateLimiter(5*time.Millisecond, 5, 3, log)
 	defer rl.ResetRate()
 
+	const totalRequests = 10
 	var wg sync.WaitGroup
-	var activeReqs int32
-	var maxActiveReqs int32
-	var errors int32
-
-	// Channel to coordinate test completion
-	done := make(chan struct{})
-	// Channel to coordinate goroutine starts
 	startCh := make(chan struct{})
-	// Channel to ensure goroutines start together
-	readyCh := make(chan struct{})
-	// Channel to track when goroutines have acquired the semaphore
-	acquiredCh := make(chan struct{}, 10)
+	errCh := make(chan error, totalRequests)
 
-	// Start a goroutine to monitor max concurrent requests
-	go func() {
-		ticker := time.NewTicker(100 * time.Microsecond) // More frequent checks
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				current := atomic.LoadInt32(&activeReqs)
-				max := atomic.LoadInt32(&maxActiveReqs)
-				if current > max {
-					if atomic.CompareAndSwapInt32(&maxActiveReqs, max, current) {
-						log.Info("New max concurrent requests", map[string]interface{}{
-							"current": current,
-							"max":     maxConcurrent,
-						})
-					}
-				}
-			}
-		}
-	}()
-
-	// Start multiple goroutines that will try to acquire tokens
-	for i := 0; i < 10; i++ {
+	for range totalRequests {
 		wg.Add(1)
-		go func(id int) {
+		go func() {
 			defer wg.Done()
-			
-			// Signal that this goroutine is ready
-			readyCh <- struct{}{}
-			
-			// Wait for the start signal
 			<-startCh
-			
-			// Use a context with a timeout to prevent hanging
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
-			
-			// Try to acquire a token first
-			err := rl.Wait(ctx)
-			if err != nil {
-				// Count errors but don't fail the test here
-				atomic.AddInt32(&errors, 1)
-				log.Info("Error acquiring token", map[string]interface{}{
-					"error": err.Error(),
-					"id":    id,
-				})
-				return
-			}
-
-			// IMPORTANT: Increment active requests AFTER acquiring the token
-			current := atomic.AddInt32(&activeReqs, 1)
-			// Signal that we've acquired the semaphore
-			acquiredCh <- struct{}{}
-
-			log.Info("Acquired token", map[string]interface{}{
-				"id":      id,
-				"current": current,
-			})
-
-			// Update max active requests
-			for {
-				max := atomic.LoadInt32(&maxActiveReqs)
-				if current > max {
-					if atomic.CompareAndSwapInt32(&maxActiveReqs, max, current) {
-						break
-					}
-				} else {
-					break
-				}
-			}
-			
-			// Simulate some work
-			time.Sleep(50 * time.Millisecond)
-			
-			// Decrement active requests and release the semaphore
-			atomic.AddInt32(&activeReqs, -1)
-			<-acquiredCh
-		}(i)
+			errCh <- rl.Wait(ctx)
+		}()
 	}
 
-	// Wait for all goroutines to be ready
-	for i := 0; i < 10; i++ {
-		<-readyCh
-	}
-
-	// Start all goroutines at the same time
 	close(startCh)
-	
-	// Wait for all goroutines to finish
 	wg.Wait()
-	close(done)
-
-	// Log the results for debugging
-	maxActive := atomic.LoadInt32(&maxActiveReqs)
-
-	t.Logf("Max concurrent requests: %d (limit: %d), Errors: %d", 
-		maxActive, maxConcurrent, atomic.LoadInt32(&errors))
-
-	// Verify that the max concurrent requests did not exceed the limit
-	if maxActive > int32(maxConcurrent) {
-		t.Errorf("Number of concurrent requests exceeded maxConcurrent (%d > %d)", 
-			maxActive, maxConcurrent)
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
 	}
-
-	// Additional verification: Check that we had some errors due to rate limiting
-	// We expect some errors since we're trying to make 10 concurrent requests with a limit of 3
-	if errors == 0 {
-		t.Error("Expected some requests to be rate limited, but got no errors")
-	}
+	assert.Equal(t, uint64(totalRequests), rl.GetMetrics().Requests)
 }
 
 func TestRateLimiterOnRateLimit(t *testing.T) {
@@ -321,8 +212,8 @@ func TestRateLimiterResetRate(t *testing.T) {
 	rl.SetBackoffFactor(2.0)
 	rl.ResetRate()
 
-	// Verify reset to defaults
-	assert.Equal(t, DefaultRate, rl.GetRate())
+	// Verify reset preserves the configured base rate.
+	assert.Equal(t, time.Second, rl.GetRate())
 	assert.Equal(t, DefaultBackoffFactor, rl.backoffFactor)
 }
 
@@ -404,5 +295,3 @@ func TestRateLimiterWithRateLimitHeaders(t *testing.T) {
 		})
 	}
 }
-
-

--- a/internal/util/rate_limiter_coverage_test.go
+++ b/internal/util/rate_limiter_coverage_test.go
@@ -2,90 +2,13 @@ package util
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/drallgood/audiobookshelf-hardcover-sync/internal/logger"
 )
-
-// testLogRecorder captures log messages for testing
-type testLogRecorder struct {
-	msgs  []string
-	mutex sync.Mutex
-}
-
-// testLogWriter is an io.Writer that captures log messages
-type testLogWriter struct {
-	recorder *testLogRecorder
-}
-
-// Write implements io.Writer interface
-func (w *testLogWriter) Write(p []byte) (n int, err error) {
-	msg := string(p)
-	// Remove trailing newline if present
-	if len(msg) > 0 && msg[len(msg)-1] == '\n' {
-		msg = msg[:len(msg)-1]
-	}
-	w.recorder.mutex.Lock()
-	defer w.recorder.mutex.Unlock()
-	w.recorder.msgs = append(w.recorder.msgs, msg)
-	return len(p), nil
-}
-
-// newTestLogger creates a new logger for testing
-func newTestLogger() (*logger.Logger, *testLogRecorder) {
-	recorder := &testLogRecorder{
-		msgs: make([]string, 0),
-	}
-	
-	// Create a buffer to capture log output
-	buf := &testLogWriter{recorder: recorder}
-	
-	// Reset the global logger for testing
-	logger.ResetForTesting()
-	
-	// Configure the global logger with our test configuration
-	logger.Setup(logger.Config{
-		Level:      "debug",
-		Format:     "json",
-		Output:     buf,
-		TimeFormat: time.RFC3339,
-	})
-	
-	// Get the global logger instance
-	log := logger.Get()
-	
-	return log, recorder
-}
-
-// hasMessage checks if a message with the given level and content was logged
-func (r *testLogRecorder) hasMessage(level, msg string) bool {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	for _, m := range r.msgs {
-		// Parse the JSON log message
-		var logEntry map[string]interface{}
-		if err := json.Unmarshal([]byte(m), &logEntry); err != nil {
-			continue
-		}
-
-		// Check if the level and message match
-		if logEntry["level"] == level && strings.Contains(logEntry["message"].(string), msg) {
-			fmt.Printf("Found matching message: %s\n", m)
-			return true
-		}
-	}
-	return false
-}
 
 func TestNewRateLimiter(t *testing.T) {
 	tests := []struct {
@@ -146,8 +69,7 @@ func TestNewRateLimiter(t *testing.T) {
 }
 
 func TestRateLimiterConcurrentAccess(t *testing.T) {
-	log, _ := newTestLogger()
-	rl := NewRateLimiter(5*time.Millisecond, 5, 3, log)
+	rl := NewRateLimiter(5*time.Millisecond, 5, 3, nil)
 	defer rl.ResetRate()
 
 	const totalRequests = 10
@@ -173,125 +95,4 @@ func TestRateLimiterConcurrentAccess(t *testing.T) {
 		require.NoError(t, err)
 	}
 	assert.Equal(t, uint64(totalRequests), rl.GetMetrics().Requests)
-}
-
-func TestRateLimiterOnRateLimit(t *testing.T) {
-	// Create a test logger
-	log, _ := newTestLogger()
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, log)
-	defer rl.ResetRate()
-
-	// First request should succeed
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-
-	err := rl.Wait(ctx)
-	require.NoError(t, err)
-
-	// Trigger rate limiting with a shorter backoff for testing
-	retryAfter := rl.OnRateLimit(100 * time.Millisecond)
-	assert.Greater(t, retryAfter, time.Duration(0), "Expected positive retry after duration")
-
-	// Next wait should be delayed due to rate limiting
-	start := time.Now()
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel2()
-
-	err = rl.Wait(ctx2)
-	elapsed := time.Since(start)
-
-	assert.NoError(t, err, "Wait should complete without error")
-	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "Expected delay after rate limiting")
-}
-
-func TestRateLimiterResetRate(t *testing.T) {
-	rl := NewRateLimiter(time.Second, 1, 1, nil)
-	defer rl.ResetRate()
-
-	// Change rate and burst
-	rl.SetBackoffFactor(2.0)
-	rl.ResetRate()
-
-	// Verify reset preserves the configured base rate.
-	assert.Equal(t, time.Second, rl.GetRate())
-	assert.Equal(t, DefaultBackoffFactor, rl.backoffFactor)
-}
-
-func TestRateLimiterGetMetrics(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 5, 10, nil)
-	defer rl.ResetRate()
-
-	// Take some tokens
-	err := rl.Wait(context.Background())
-	require.NoError(t, err)
-
-	// Get metrics
-	metrics := rl.GetMetrics()
-
-	// Verify metrics
-	assert.Greater(t, metrics.Requests, uint64(0))
-	assert.Equal(t, "100ms", metrics.CurrentRate)
-}
-
-func TestRateLimiterWithRateLimitHeaders(t *testing.T) {
-	tests := []struct {
-		name          string
-		headers       map[string]string
-		expectBackoff bool
-	}{
-		{
-			name: "rate limit headers",
-			headers: map[string]string{
-				"X-RateLimit-Remaining": "0",
-				"X-RateLimit-Limit":     "100",
-				"Retry-After":           "1",
-			},
-			expectBackoff: true,
-		},
-		{
-			name: "no rate limit",
-			headers: map[string]string{
-				"X-RateLimit-Remaining": "10",
-				"X-RateLimit-Limit":     "100",
-			},
-			expectBackoff: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a new test logger for each test case to isolate them
-			log, logRecorder := newTestLogger()
-			rl := NewRateLimiter(100*time.Millisecond, 5, 10, log)
-			defer rl.ResetRate()
-
-			resp := &http.Response{
-				Header: make(http.Header),
-			}
-
-			// Set headers
-			for k, v := range tt.headers {
-				resp.Header.Set(k, v)
-			}
-
-			// Process headers
-			rl.WithRateLimitHeaders(resp)
-
-			// Debug: Print all logged messages
-			for _, msg := range logRecorder.msgs {
-				t.Logf("Logged message: %s", msg)
-			}
-
-			// Verify behavior
-			if tt.expectBackoff {
-				// Check for the exact log message that's being generated
-				assert.True(t, logRecorder.hasMessage("warn", "Rate limit error with retry-after header"), 
-					"Expected rate limit warning")
-			} else {
-				// For the no rate limit case, we should not see the rate limit error message
-				assert.False(t, logRecorder.hasMessage("warn", "Rate limit error with retry-after header"), 
-					"Unexpected rate limit warning")
-			}
-		})
-	}
 }

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -437,6 +437,30 @@ func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
 	assert.LessOrEqual(t, pause, DefaultMaxBackoff)
 }
 
+func TestRateLimiterDailyExhaustionOverridesRetryAfter(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
+	dailyResetSeconds := int(DefaultMaxDailyResetWait/time.Second) + 1
+	rl.WithRateLimitHeaders(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Retry-After": {"1"},
+			"Ratelimit": {
+				fmt.Sprintf(`"Free";r=59;t=1, "daily";r=0;t=%d`, dailyResetSeconds),
+			},
+			"Ratelimit-Policy": {`"Free";q=60;w=60, "daily";q=5000;w=86400`},
+		},
+	})
+
+	rl.mu.RLock()
+	pause := rl.backoffUntil.Sub(time.Now())
+	rl.mu.RUnlock()
+	assert.Greater(t, pause, DefaultMaxBackoff)
+	assert.LessOrEqual(t, pause, DefaultMaxDailyResetWait)
+	assert.Equal(t, 0, rl.DailyRemaining())
+	assert.Equal(t, 5000, rl.DailyLimit())
+	assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
+}
+
 func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -663,6 +663,45 @@ func TestRateLimiterIETFZeroResetDoesNotCreatePermanentBackoff(t *testing.T) {
 	assert.Zero(t, rl.checkBackoff())
 }
 
+func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
+	serverDelaySeconds := int(DefaultMaxBackoff/time.Second) + 1
+	serverDelay := time.Duration(serverDelaySeconds) * time.Second
+	require.Greater(t, serverDelay, DefaultMaxBackoff)
+
+	tests := []struct {
+		name string
+		resp *http.Response
+	}{
+		{
+			name: "Retry-After",
+			resp: &http.Response{Header: http.Header{
+				"Retry-After": {strconv.Itoa(serverDelaySeconds)},
+			}},
+		},
+		{
+			name: "exhausted daily IETF reset",
+			resp: &http.Response{Header: http.Header{
+				"Ratelimit":        {fmt.Sprintf(`"daily";r=0;t=%d`, serverDelaySeconds)},
+				"Ratelimit-Policy": {`"daily";q=5000;w=86400`},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl.WithRateLimitHeaders(tt.resp)
+
+			rl.mu.RLock()
+			pause := rl.checkBackoff()
+			rl.mu.RUnlock()
+
+			assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
+			assert.LessOrEqual(t, pause, DefaultMaxBackoff)
+		})
+	}
+}
+
 func TestRateLimiterUsesPolicyWindowForSteadyPacing(t *testing.T) {
 	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
 	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -51,6 +51,15 @@ func init() {
 	testMode = true
 }
 
+func acquireAndRelease(ctx context.Context, rl *RateLimiter) error {
+	release, err := rl.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	release()
+	return nil
+}
+
 func TestRateLimiter_ContextCancellation(t *testing.T) {
 	t.Run("context canceled", func(t *testing.T) {
 		log := setupTestLogger(t)
@@ -61,12 +70,12 @@ func TestRateLimiter_ContextCancellation(t *testing.T) {
 		defer cancel()
 
 		// This should fail due to context timeout
-		err := rl.Wait(ctx)
+		err := acquireAndRelease(ctx, rl)
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 }
 
-func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
+func TestRateLimiter_ConcurrentAcquiresArePaced(t *testing.T) {
 	const (
 		interval      = 15 * time.Millisecond
 		totalRequests = 5
@@ -82,7 +91,7 @@ func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
 	for range totalRequests {
 		go func() {
 			<-start
-			err := rl.Wait(context.Background())
+			err := acquireAndRelease(context.Background(), rl)
 			completed <- result{completedAt: time.Now(), err: err}
 		}()
 	}
@@ -99,7 +108,7 @@ func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
 	}
 }
 
-func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
+func TestRateLimiter_PendingAcquireObservesNewBackoff(t *testing.T) {
 	const (
 		interval = 100 * time.Millisecond
 		backoff  = 160 * time.Millisecond
@@ -112,7 +121,7 @@ func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
 	completed := make(chan result, 1)
 
 	go func() {
-		err := rl.Wait(context.Background())
+		err := acquireAndRelease(context.Background(), rl)
 		completed <- result{completedAt: time.Now(), err: err}
 	}()
 	require.Eventually(t, func() bool {
@@ -125,10 +134,10 @@ func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
 	require.NoError(t, got.err)
 
 	assert.GreaterOrEqual(t, got.completedAt.Sub(backoffStarted), 140*time.Millisecond,
-		"pending waiter was admitted before the new backoff expired")
+		"pending acquire was admitted before the new backoff expired")
 }
 
-func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
+func TestRateLimiter_CancellationDoesNotCollapsePendingAcquires(t *testing.T) {
 	const interval = 80 * time.Millisecond
 	rl := NewRateLimiter(interval, 3, setupTestLogger(t))
 	type result struct {
@@ -138,7 +147,7 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 	completed := make(chan result, 2)
 
 	go func() {
-		err := rl.Wait(context.Background())
+		err := acquireAndRelease(context.Background(), rl)
 		completed <- result{completedAt: time.Now(), err: err}
 	}()
 	require.Eventually(t, func() bool {
@@ -148,7 +157,7 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	canceled := make(chan error, 1)
 	go func() {
-		canceled <- rl.Wait(cancelCtx)
+		canceled <- acquireAndRelease(cancelCtx, rl)
 	}()
 	require.Eventually(t, func() bool {
 		return rl.GetMetrics().Requests == 2
@@ -157,7 +166,7 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 	require.ErrorIs(t, <-canceled, context.Canceled)
 
 	go func() {
-		err := rl.Wait(context.Background())
+		err := acquireAndRelease(context.Background(), rl)
 		completed <- result{completedAt: time.Now(), err: err}
 	}()
 
@@ -166,7 +175,7 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 	require.NoError(t, first.err)
 	require.NoError(t, second.err)
 	assert.GreaterOrEqual(t, second.completedAt.Sub(first.completedAt), 60*time.Millisecond,
-		"cancellation allowed two pending waiters into the same pacing slot")
+		"cancellation allowed two pending acquires into the same pacing slot")
 }
 
 func TestRateLimiter_OnRateLimit(t *testing.T) {
@@ -178,6 +187,25 @@ func TestRateLimiter_OnRateLimit(t *testing.T) {
 	assert.Equal(t, 10*time.Second, waitTime)
 	assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must remain a temporary pause")
 	assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
+}
+
+func TestRateLimiter_OnRateLimitFallbackPreservesLongerAuthoritativePause(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
+	rl.SetBackoffFactor(2)
+	rl.SetJitterFactor(0)
+
+	rl.OnRateLimit(2 * time.Second)
+	rl.mu.RLock()
+	authoritativeDeadline := rl.backoffUntil
+	rl.mu.RUnlock()
+
+	assert.Equal(t, 200*time.Millisecond, rl.OnRateLimit(0))
+	rl.mu.RLock()
+	actualDeadline := rl.backoffUntil
+	rl.mu.RUnlock()
+
+	assert.False(t, actualDeadline.Before(authoritativeDeadline),
+		"exponential fallback must not shorten an authoritative pause")
 }
 
 func TestRateLimiter_ResetRate(t *testing.T) {
@@ -207,7 +235,7 @@ func TestRateLimiter_GetMetrics(t *testing.T) {
 
 	// Make a request
 	ctx := context.Background()
-	err := rl.Wait(ctx)
+	err := acquireAndRelease(ctx, rl)
 	require.NoError(t, err)
 
 	// Check updated metrics
@@ -388,21 +416,6 @@ func TestParseIETFRateLimitPolicy(t *testing.T) {
 	assert.Equal(t, 86400, window["daily"])
 }
 
-func TestRateLimiterWaitDoesNotAccelerate(t *testing.T) {
-	const interval = 15 * time.Millisecond
-	rl := NewRateLimiter(interval, 1, nil)
-
-	var previous time.Time
-	for range 6 {
-		require.NoError(t, rl.Wait(context.Background()))
-		now := time.Now()
-		if !previous.IsZero() {
-			assert.GreaterOrEqual(t, now.Sub(previous), 12*time.Millisecond)
-		}
-		previous = now
-	}
-}
-
 func TestRateLimiterIETFZeroResetDoesNotCreatePermanentBackoff(t *testing.T) {
 	configuredRate := 2 * time.Second
 	rl := NewRateLimiter(configuredRate, 1, nil)
@@ -493,6 +506,70 @@ func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 
 			assert.Greater(t, pause, tt.expectedPause-time.Second)
 			assert.LessOrEqual(t, pause, tt.expectedPause)
+		})
+	}
+}
+
+func TestRateLimiterBoundsExtremeNonExhaustedIETFValues(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	extreme := strconv.Itoa(maxInt)
+	tests := []struct {
+		name        string
+		rateLimit   string
+		policy      string
+		wantRate    time.Duration
+		wantBackoff bool
+	}{
+		{
+			name:        "near exhausted daily reset",
+			rateLimit:   fmt.Sprintf(`"daily";r=1;t=%s`, extreme),
+			policy:      fmt.Sprintf(`"daily";q=%s;w=86400`, extreme),
+			wantRate:    DefaultMaxBackoff,
+			wantBackoff: false,
+		},
+		{
+			name:        "sustainable window",
+			rateLimit:   `"free";r=2;t=1`,
+			policy:      fmt.Sprintf(`"free";q=1;w=%s`, extreme),
+			wantRate:    DefaultMaxBackoff,
+			wantBackoff: false,
+		},
+		{
+			name:        "near exhausted non daily pause",
+			rateLimit:   fmt.Sprintf(`"free";r=1;t=%s`, extreme),
+			policy:      `"free";q=60;w=60`,
+			wantRate:    time.Second,
+			wantBackoff: true,
+		},
+		{
+			name:        "malformed extreme values",
+			rateLimit:   `"free";r=1;t=999999999999999999999999999999`,
+			policy:      `"free";q=60;w=999999999999999999999999999999`,
+			wantRate:    100 * time.Millisecond,
+			wantBackoff: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewRateLimiter(100*time.Millisecond, 1, nil)
+			rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+				"Ratelimit":        {tt.rateLimit},
+				"Ratelimit-Policy": {tt.policy},
+			}})
+
+			assert.Equal(t, tt.wantRate, rl.GetRate())
+			assert.GreaterOrEqual(t, rl.GetRate(), time.Duration(0))
+			assert.LessOrEqual(t, rl.GetRate(), DefaultMaxBackoff)
+			rl.mu.RLock()
+			pause := time.Until(rl.backoffUntil)
+			backoffSet := !rl.backoffUntil.IsZero()
+			rl.mu.RUnlock()
+			assert.Equal(t, tt.wantBackoff, backoffSet)
+			if backoffSet {
+				assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
+				assert.LessOrEqual(t, pause, DefaultMaxBackoff)
+			}
 		})
 	}
 }

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -535,7 +535,7 @@ func TestRateLimiterUnguided429PreservesLongerBackoff(t *testing.T) {
 	rl.mu.RLock()
 	actualDeadline := rl.backoffUntil
 	rl.mu.RUnlock()
-	assert.Equal(t, authoritativeDeadline, actualDeadline, "shorter fallback must not replace authoritative backoff")
+	assert.False(t, actualDeadline.Before(authoritativeDeadline), "fallback must not shorten authoritative backoff")
 }
 
 func TestRateLimiterFallsBackForUnguidedTooManyRequests(t *testing.T) {

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -50,164 +49,6 @@ func containsLogEntry(t *testing.T, output, level, message string) bool {
 func init() {
 	// Enable test mode to disable buffering in ParseRetryAfter
 	testMode = true
-}
-
-func TestRateLimiter_Wait(t *testing.T) {
-	tests := []struct {
-		name          string
-		rate          time.Duration
-		burst         int
-		maxConcurrent int
-		reqCount      int
-		expectError   bool
-		setup         func(*RateLimiter) // Optional setup function for the rate limiter
-		minTime       time.Duration      // Minimum expected time for the test to complete
-	}{
-		{
-			name:          "single request",
-			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
-			burst:         1,
-			maxConcurrent: 1,
-			reqCount:      1,
-			expectError:   false,
-			minTime:       0, // No minimum time for a single request
-		},
-		{
-			name:          "multiple requests within burst",
-			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
-			burst:         5,
-			maxConcurrent: 5,
-			reqCount:      3,
-			expectError:   false,
-			minTime:       0, // No rate limiting within burst
-		},
-		{
-			name:          "concurrent requests with rate limiting",
-			rate:          time.Millisecond * 50, // Reduced from 200ms for faster tests
-			burst:         2,
-			maxConcurrent: 10,
-			reqCount:      5, // Reduced from 10 to make test faster
-			expectError:   false,
-			minTime:       time.Duration(5-2) * 50 * time.Millisecond, // (reqCount - burst) * rate
-		},
-		{
-			name:          "context canceled",
-			rate:          time.Hour, // Very slow rate to ensure we hit the context timeout
-			burst:         1,
-			maxConcurrent: 1,
-			reqCount:      1,
-			expectError:   true,
-			minTime:       0, // Not relevant for this test case
-			setup: func(rl *RateLimiter) {
-				rl.SetBackoffFactor(1.0) // Disable backoff for this test
-			},
-		},
-		{
-			name:          "with backoff",
-			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
-			burst:         1,
-			maxConcurrent: 3, // Increased to allow the test to run
-			reqCount:      2, // Reduced from 3 to make test faster
-			expectError:   false,
-			minTime:       time.Second, // Backoff is set to 1 second
-			setup: func(rl *RateLimiter) {
-				rl.SetBackoffFactor(2.0)
-				// Simulate a rate limit to trigger backoff
-				rl.mu.Lock()
-				rl.backoffUntil = time.Now().Add(time.Second)
-				rl.mu.Unlock()
-				// Log the backoff state for debugging
-				rl.logger.Debug("Test setup: Backoff set", map[string]interface{}{
-					"backoff_until": rl.backoffUntil,
-					"now":           time.Now(),
-				})
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(tt.rate, tt.burst, tt.maxConcurrent, nil)
-			// Apply any test-specific setup
-			if tt.setup != nil {
-				tt.setup(rl)
-			}
-
-			var wg sync.WaitGroup
-			start := time.Now()
-			errCh := make(chan error, tt.reqCount)
-
-			for i := 0; i < tt.reqCount; i++ {
-				wg.Add(1)
-				go func(i int) {
-					defer wg.Done()
-					// For the context canceled test, create a canceled context
-					var ctx context.Context
-					if tt.name == "context canceled" {
-						var cancel context.CancelFunc
-						ctx, cancel = context.WithCancel(context.Background())
-						cancel() // Immediately cancel the context
-					} else {
-						ctx = context.Background()
-					}
-
-					err := rl.Wait(ctx)
-					if tt.expectError {
-						errCh <- err
-					} else if err != nil {
-						errCh <- fmt.Errorf("unexpected error: %v", err)
-					} else {
-						errCh <- nil
-					}
-				}(i)
-			}
-
-			// Wait for all goroutines to complete
-			wg.Wait()
-			close(errCh)
-
-			// Check for any errors
-			for err := range errCh {
-				if tt.expectError {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-				}
-			}
-
-			// For tests that don't expect errors, verify timing if specified
-			if !tt.expectError && tt.minTime > 0 {
-				elapsed := time.Since(start)
-				// Allow for some timing slack (80% of expected time)
-				minAllowedTime := time.Duration(float64(tt.minTime) * 0.8)
-				assert.GreaterOrEqual(t, elapsed, minAllowedTime,
-					"test %s: expected at least %v, got %v", tt.name, minAllowedTime, elapsed)
-			}
-		})
-	}
-}
-
-func TestRateLimiter_BasicRateLimiting(t *testing.T) {
-	t.Run("basic rate limiting", func(t *testing.T) {
-		rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
-		defer rl.ResetRate()
-
-		start := time.Now()
-		ctx := context.Background()
-
-		// First request should pass immediately
-		err := rl.Wait(ctx)
-		require.NoError(t, err)
-
-		// Second request should be rate limited
-		err = rl.Wait(ctx)
-		require.NoError(t, err)
-		elapsed := time.Since(start)
-
-		// Should take at least 80ms due to rate limiting (allowing for some timing variation)
-		// The actual rate is 100ms, but timing can vary slightly due to scheduling
-		assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "expected at least 80ms delay, got %v", elapsed)
-	})
 }
 
 func TestRateLimiter_ContextCancellation(t *testing.T) {
@@ -892,6 +733,12 @@ func TestRateLimiterRecoversFromHeaderDrivenSlowdown(t *testing.T) {
 }
 
 func TestRateLimiterAdaptivePacingLogLevels(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLevel)
+	})
+
 	t.Run("IETF window adjustment is info", func(t *testing.T) {
 		var logs bytes.Buffer
 		testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.DebugLevel)}

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -733,6 +733,113 @@ func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
 	assert.Equal(t, 100*time.Millisecond, rl.GetRate())
 }
 
+func TestRateLimiterFallsBackForUnguidedTooManyRequests(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
+	tests := []struct {
+		name   string
+		header http.Header
+	}{
+		{
+			name: "legacy reset without remaining",
+			header: http.Header{
+				"X-RateLimit-Reset": {reset},
+			},
+		},
+		{
+			name: "malformed legacy remaining",
+			header: http.Header{
+				"X-RateLimit-Remaining": {"unknown"},
+				"X-RateLimit-Reset":     {reset},
+			},
+		},
+		{
+			name: "nonzero legacy remaining",
+			header: http.Header{
+				"X-RateLimit-Limit":     {"100"},
+				"X-RateLimit-Remaining": {"10"},
+				"X-RateLimit-Reset":     {reset},
+			},
+		},
+		{
+			name: "non-exhausted IETF quota",
+			header: http.Header{
+				"RateLimit":        {`"Free";r=8;t=42`},
+				"RateLimit-Policy": {`"Free";q=60;w=60;burst=10`},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl.SetBackoffFactor(2)
+			rl.SetJitterFactor(0)
+
+			rl.WithRateLimitHeaders(&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     tt.header,
+			})
+
+			assert.Equal(t, 200*time.Millisecond, rl.GetRate())
+			assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
+			rl.mu.RLock()
+			assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+			rl.mu.RUnlock()
+		})
+	}
+}
+
+func TestRateLimiterHonorsAuthoritativeTooManyRequestsGuidance(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
+	tests := []struct {
+		name         string
+		header       http.Header
+		expectedRate time.Duration
+	}{
+		{
+			name:         "positive Retry-After",
+			expectedRate: 100 * time.Millisecond,
+			header: http.Header{
+				"Retry-After": {"1"},
+			},
+		},
+		{
+			name:         "exhausted IETF quota",
+			expectedRate: time.Second,
+			header: http.Header{
+				"Ratelimit":        {`"Free";r=0;t=42`},
+				"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
+			},
+		},
+		{
+			name:         "exhausted legacy quota",
+			expectedRate: 100 * time.Millisecond,
+			header: http.Header{
+				"X-Ratelimit-Limit":     {"100"},
+				"X-Ratelimit-Remaining": {"0"},
+				"X-Ratelimit-Reset":     {reset},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl.SetBackoffFactor(2)
+			rl.SetJitterFactor(0)
+			rl.WithRateLimitHeaders(&http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     tt.header,
+			})
+
+			assert.Equal(t, tt.expectedRate, rl.GetRate())
+			rl.mu.RLock()
+			assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+			rl.mu.RUnlock()
+		})
+	}
+}
+
 func TestRateLimiterRecoversFromHeaderDrivenSlowdown(t *testing.T) {
 	configuredRate := 2 * time.Second
 	var logs bytes.Buffer

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -258,6 +258,76 @@ func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
+	const (
+		interval = 100 * time.Millisecond
+		backoff  = 160 * time.Millisecond
+	)
+	rl := NewRateLimiter(interval, 1, 2, setupTestLogger(t))
+	type result struct {
+		completedAt time.Time
+		err         error
+	}
+	completed := make(chan result, 1)
+
+	go func() {
+		err := rl.Wait(context.Background())
+		completed <- result{completedAt: time.Now(), err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return rl.GetMetrics().Requests == 1
+	}, time.Second, time.Millisecond)
+
+	backoffStarted := time.Now()
+	rl.OnRateLimit(backoff)
+	got := <-completed
+	require.NoError(t, got.err)
+
+	assert.GreaterOrEqual(t, got.completedAt.Sub(backoffStarted), 140*time.Millisecond,
+		"pending waiter was admitted before the new backoff expired")
+}
+
+func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
+	const interval = 80 * time.Millisecond
+	rl := NewRateLimiter(interval, 1, 3, setupTestLogger(t))
+	type result struct {
+		completedAt time.Time
+		err         error
+	}
+	completed := make(chan result, 2)
+
+	go func() {
+		err := rl.Wait(context.Background())
+		completed <- result{completedAt: time.Now(), err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return rl.GetMetrics().Requests == 1
+	}, time.Second, time.Millisecond)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	canceled := make(chan error, 1)
+	go func() {
+		canceled <- rl.Wait(cancelCtx)
+	}()
+	require.Eventually(t, func() bool {
+		return rl.GetMetrics().Requests == 2
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-canceled, context.Canceled)
+
+	go func() {
+		err := rl.Wait(context.Background())
+		completed <- result{completedAt: time.Now(), err: err}
+	}()
+
+	first := <-completed
+	second := <-completed
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	assert.GreaterOrEqual(t, second.completedAt.Sub(first.completedAt), 60*time.Millisecond,
+		"cancellation allowed two pending waiters into the same pacing slot")
+}
+
 const (
 	// Default backoff factor for testing
 	testDefaultBackoffFactor = 8.0 // This matches the default in the implementation

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -1,18 +1,21 @@
 package util
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/drallgood/audiobookshelf-hardcover-sync/internal/logger"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,6 +33,20 @@ func setupTestLogger(t *testing.T) *logger.Logger {
 	return logger.Get()
 }
 
+func containsLogEntry(t *testing.T, output, level, message string) bool {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["level"] == level && entry["message"] == message {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	// Enable test mode to disable buffering in ParseRetryAfter
 	testMode = true
@@ -37,18 +54,18 @@ func init() {
 
 func TestRateLimiter_Wait(t *testing.T) {
 	tests := []struct {
-		name           string
-		rate           time.Duration
+		name          string
+		rate          time.Duration
 		burst         int
 		maxConcurrent int
 		reqCount      int
 		expectError   bool
 		setup         func(*RateLimiter) // Optional setup function for the rate limiter
-		minTime       time.Duration     // Minimum expected time for the test to complete
+		minTime       time.Duration      // Minimum expected time for the test to complete
 	}{
 		{
-			name:           "single request",
-			rate:           time.Millisecond * 50, // Reduced from 100ms for faster tests
+			name:          "single request",
+			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
 			burst:         1,
 			maxConcurrent: 1,
 			reqCount:      1,
@@ -56,8 +73,8 @@ func TestRateLimiter_Wait(t *testing.T) {
 			minTime:       0, // No minimum time for a single request
 		},
 		{
-			name:           "multiple requests within burst",
-			rate:           time.Millisecond * 50, // Reduced from 100ms for faster tests
+			name:          "multiple requests within burst",
+			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
 			burst:         5,
 			maxConcurrent: 5,
 			reqCount:      3,
@@ -65,8 +82,8 @@ func TestRateLimiter_Wait(t *testing.T) {
 			minTime:       0, // No rate limiting within burst
 		},
 		{
-			name:           "concurrent requests with rate limiting",
-			rate:           time.Millisecond * 50, // Reduced from 200ms for faster tests
+			name:          "concurrent requests with rate limiting",
+			rate:          time.Millisecond * 50, // Reduced from 200ms for faster tests
 			burst:         2,
 			maxConcurrent: 10,
 			reqCount:      5, // Reduced from 10 to make test faster
@@ -74,8 +91,8 @@ func TestRateLimiter_Wait(t *testing.T) {
 			minTime:       time.Duration(5-2) * 50 * time.Millisecond, // (reqCount - burst) * rate
 		},
 		{
-			name:           "context canceled",
-			rate:           time.Hour, // Very slow rate to ensure we hit the context timeout
+			name:          "context canceled",
+			rate:          time.Hour, // Very slow rate to ensure we hit the context timeout
 			burst:         1,
 			maxConcurrent: 1,
 			reqCount:      1,
@@ -86,8 +103,8 @@ func TestRateLimiter_Wait(t *testing.T) {
 			},
 		},
 		{
-			name:           "with backoff",
-			rate:           time.Millisecond * 50, // Reduced from 100ms for faster tests
+			name:          "with backoff",
+			rate:          time.Millisecond * 50, // Reduced from 100ms for faster tests
 			burst:         1,
 			maxConcurrent: 3, // Increased to allow the test to run
 			reqCount:      2, // Reduced from 3 to make test faster
@@ -163,7 +180,7 @@ func TestRateLimiter_Wait(t *testing.T) {
 				elapsed := time.Since(start)
 				// Allow for some timing slack (80% of expected time)
 				minAllowedTime := time.Duration(float64(tt.minTime) * 0.8)
-				assert.GreaterOrEqual(t, elapsed, minAllowedTime, 
+				assert.GreaterOrEqual(t, elapsed, minAllowedTime,
 					"test %s: expected at least %v, got %v", tt.name, minAllowedTime, elapsed)
 			}
 		})
@@ -208,87 +225,37 @@ func TestRateLimiter_ContextCancellation(t *testing.T) {
 	})
 }
 
-func TestRateLimiter_ConcurrencyLimiting(t *testing.T) {
-	t.Run("concurrency limiting", func(t *testing.T) {
-		log := setupTestLogger(t)
-		
-		// Use a very slow rate to ensure we hit concurrency limits before rate limits
-		rate := 10 * time.Second
-		burst := 1
-		maxConcurrent := 2
-		totalRequests := 5
+func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
+	const (
+		interval      = 15 * time.Millisecond
+		totalRequests = 5
+	)
+	rl := NewRateLimiter(interval, 1, 2, setupTestLogger(t))
+	start := make(chan struct{})
+	type result struct {
+		completedAt time.Time
+		err         error
+	}
+	completed := make(chan result, totalRequests)
 
-		t.Logf("Starting test with maxConcurrent=%d, totalRequests=%d", maxConcurrent, totalRequests)
+	for range totalRequests {
+		go func() {
+			<-start
+			err := rl.Wait(context.Background())
+			completed <- result{completedAt: time.Now(), err: err}
+		}()
+	}
+	close(start)
 
-		rateLimiter := NewRateLimiter(rate, burst, maxConcurrent, log)
-		t.Logf("Rate limiter created: rate=%v, burst=%d, maxConcurrent=%d", rate, burst, rateLimiter.maxConcurrent)
-
-		// Channel to coordinate goroutine startup
-		startCh := make(chan struct{})
-
-		// Channel to collect errors
-		errCh := make(chan error, totalRequests)
-
-		// Channel to signal when each goroutine is done
-		doneCh := make(chan struct{}, totalRequests)
-
-		// Track the number of active requests
-		var activeReqs int32
-		var maxActive int32
-
-		// Start all the goroutines
-		for i := 0; i < totalRequests; i++ {
-			go func(id int) {
-				// Wait for the start signal
-				<-startCh
-
-				// Call the rate limiter to acquire the semaphore
-				err := rateLimiter.Wait(context.Background())
-				if err != nil {
-					errCh <- fmt.Errorf("goroutine %d: %v", id, err)
-					doneCh <- struct{}{}
-					return
-				}
-
-				// Track active requests
-				current := atomic.AddInt32(&activeReqs, 1)
-				for {
-					prevMax := atomic.LoadInt32(&maxActive)
-					if current <= prevMax || atomic.CompareAndSwapInt32(&maxActive, prevMax, current) {
-						break
-					}
-				}
-
-				// Simulate work
-				time.Sleep(100 * time.Millisecond)
-
-				// Mark request as done
-				atomic.AddInt32(&activeReqs, -1)
-				doneCh <- struct{}{}
-			}(i)
-		}
-
-		// Start all requests at once
-		close(startCh)
-
-		// Wait for all goroutines to complete
-		for i := 0; i < totalRequests; i++ {
-			select {
-			case err := <-errCh:
-				t.Error(err)
-			case <-doneCh:
-				// Goroutine completed
-			}
-		}
-
-		// Verify max concurrency was respected
-		maxConcurrentReached := atomic.LoadInt32(&maxActive)
-		if maxConcurrentReached > int32(maxConcurrent) {
-			t.Errorf("Max concurrency exceeded: got %d, want <= %d", maxConcurrentReached, maxConcurrent)
-		} else {
-			t.Logf("Max concurrency was properly limited to %d", maxConcurrentReached)
-		}
-	})
+	first := <-completed
+	require.NoError(t, first.err)
+	previous := first.completedAt
+	for range totalRequests - 1 {
+		current := <-completed
+		require.NoError(t, current.err)
+		assert.GreaterOrEqual(t, current.completedAt.Sub(previous), 12*time.Millisecond)
+		previous = current.completedAt
+	}
 }
 
 const (
@@ -321,12 +288,8 @@ func TestRateLimiter_OnRateLimit(t *testing.T) {
 				// No special setup needed for this test case
 			},
 			check: func(t *testing.T, waitTime time.Duration, rl *RateLimiter) {
-				// With the default backoff factor of 8.0, we expect waitTime to be around 800ms (100ms * 8.0)
-				// The actual calculation includes some additional factors, so we'll use a range
-				expectedMin := 100 * time.Millisecond
-				expectedMax := 2 * time.Second
-				assert.GreaterOrEqual(t, waitTime, expectedMin, "wait time should be at least %v", expectedMin)
-				assert.LessOrEqual(t, waitTime, expectedMax, "wait time should be at most %v", expectedMax)
+				assert.Equal(t, 100*time.Millisecond, waitTime)
+				assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must not permanently change request pacing")
 
 				// Verify metrics
 				metrics := rl.GetMetrics()
@@ -341,13 +304,8 @@ func TestRateLimiter_OnRateLimit(t *testing.T) {
 				rl.SetBackoffFactor(1.5)
 			},
 			check: func(t *testing.T, waitTime time.Duration, rl *RateLimiter) {
-				// With backoff factor of 1.5, we expect waitTime to be around 15s (10s * 1.5)
-				// The actual calculation includes some additional factors, so we'll use a range
-				// Using 9s instead of 10s to account for test environment timing variations
-				expectedMin := 9 * time.Second
-				expectedMax := 30 * time.Second
-				assert.GreaterOrEqual(t, waitTime, expectedMin, "wait time should be at least %v (was %v)", expectedMin, waitTime)
-				assert.LessOrEqual(t, waitTime, expectedMax, "wait time should be at most %v (was %v)", expectedMax, waitTime)
+				assert.Equal(t, 10*time.Second, waitTime)
+				assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must remain a temporary pause")
 
 				// Verify metrics
 				metrics := rl.GetMetrics()
@@ -385,8 +343,8 @@ func TestRateLimiter_ResetRate(t *testing.T) {
 	// Reset the rate
 	rl.ResetRate()
 
-	// Should be back to the default (2 seconds)
-	assert.Equal(t, 2*time.Second, rl.GetRate(), "rate should be reset to default 2 seconds")
+	// Should be back to the rate configured for this limiter.
+	assert.Equal(t, time.Second, rl.GetRate())
 }
 
 func TestRateLimiter_GetMetrics(t *testing.T) {
@@ -474,17 +432,17 @@ func TestRateLimiter_CalculateJitter(t *testing.T) {
 func TestParseRetryAfter(t *testing.T) {
 	// Use a fixed time for testing
 	fixedTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
-	
+
 	// Override time.Now for this test
 	origNow := timeNow
 	timeNow = func() time.Time { return fixedTime }
 	defer func() { timeNow = origNow }()
 
 	tests := []struct {
-		name     string
-		header   string
-		setup    func()
-		check    func(t *testing.T, d time.Duration, err error)
+		name   string
+		header string
+		setup  func()
+		check  func(t *testing.T, d time.Duration, err error)
 	}{
 		{
 			name:   "seconds",
@@ -595,11 +553,135 @@ func TestParseIETFRateLimitPolicy(t *testing.T) {
 	headers.Set("RateLimit-Policy", `"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400`)
 
 	var rl RateLimiter
-	quota, burst := rl.parseIETFRateLimitPolicy(headers)
+	quota, burst, window := rl.parseIETFRateLimitPolicy(headers)
 
 	assert.Equal(t, 60, quota["free"])
 	assert.Equal(t, 5000, quota["daily"])
 	assert.Equal(t, 10, burst["free"])
+	assert.Equal(t, 60, window["free"])
+	assert.Equal(t, 86400, window["daily"])
+}
+
+func TestRateLimiterWaitDoesNotAccelerate(t *testing.T) {
+	const interval = 15 * time.Millisecond
+	rl := NewRateLimiter(interval, 1, 1, nil)
+
+	var previous time.Time
+	for range 6 {
+		require.NoError(t, rl.Wait(context.Background()))
+		now := time.Now()
+		if !previous.IsZero() {
+			assert.GreaterOrEqual(t, now.Sub(previous), 12*time.Millisecond)
+		}
+		previous = now
+	}
+}
+
+func TestRateLimiterIETFZeroResetDoesNotCreatePermanentBackoff(t *testing.T) {
+	configuredRate := 2 * time.Second
+	rl := NewRateLimiter(configuredRate, 1, 1, nil)
+	resp := &http.Response{Header: http.Header{
+		"Ratelimit":        {`"Free";r=1;t=0`},
+		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
+	}}
+
+	rl.WithRateLimitHeaders(resp)
+
+	assert.Equal(t, configuredRate, rl.GetRate())
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	assert.Zero(t, rl.checkBackoff())
+}
+
+func TestRateLimiterUsesPolicyWindowForSteadyPacing(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+		"Ratelimit":        {`"Free";r=8;t=42`},
+		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
+	}})
+
+	assert.Equal(t, time.Second, rl.GetRate())
+}
+
+func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl.SetBackoffFactor(2)
+	rl.SetJitterFactor(0)
+
+	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}})
+
+	assert.Equal(t, 200*time.Millisecond, rl.GetRate())
+	assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
+	rl.mu.RLock()
+	assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+	rl.mu.RUnlock()
+
+	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}})
+	assert.Equal(t, 400*time.Millisecond, rl.GetRate())
+	assert.Equal(t, uint64(2), rl.GetMetrics().RateLimited)
+
+	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusOK, Header: http.Header{}})
+	assert.Equal(t, 100*time.Millisecond, rl.GetRate())
+}
+
+func TestRateLimiterRecoversFromHeaderDrivenSlowdown(t *testing.T) {
+	configuredRate := 2 * time.Second
+	var logs bytes.Buffer
+	testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.InfoLevel)}
+	rl := NewRateLimiter(configuredRate, 1, 1, testLogger)
+
+	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+		"Ratelimit":        {`"Free";r=8;t=42, "daily";r=1;t=10`},
+		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400`},
+	}})
+	assert.Greater(t, rl.GetRate(), configuredRate)
+
+	logs.Reset()
+	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+		"Ratelimit":        {`"Free";r=8;t=42, "daily";r=4000;t=1000`},
+		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400`},
+	}})
+	assert.Equal(t, configuredRate, rl.GetRate())
+	assert.Contains(t, logs.String(), `"level":"info"`)
+	assert.Contains(t, logs.String(), `"previous_rate":"10s"`)
+	assert.Contains(t, logs.String(), `"new_rate":"2s"`)
+	assert.Contains(t, logs.String(), `"message":"Rate limiter pacing recovered"`)
+}
+
+func TestRateLimiterAdaptivePacingLogLevels(t *testing.T) {
+	t.Run("IETF window adjustment is info", func(t *testing.T) {
+		var logs bytes.Buffer
+		testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.DebugLevel)}
+		rl := NewRateLimiter(100*time.Millisecond, 1, 1, testLogger)
+		logs.Reset()
+
+		rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+			"Ratelimit":        {`"Free";r=1;t=10`},
+			"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
+		}})
+
+		message := "Rate limit window nearly exhausted, slowing down"
+		assert.True(t, containsLogEntry(t, logs.String(), "info", message))
+		assert.False(t, containsLogEntry(t, logs.String(), "warn", message))
+	})
+
+	t.Run("legacy adjustment is info and reset schedule is debug", func(t *testing.T) {
+		var logs bytes.Buffer
+		testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.DebugLevel)}
+		rl := NewRateLimiter(100*time.Millisecond, 1, 1, testLogger)
+		logs.Reset()
+
+		header := make(http.Header)
+		header.Set("X-RateLimit-Limit", "100")
+		header.Set("X-RateLimit-Remaining", "10")
+		header.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10))
+		rl.WithRateLimitHeaders(&http.Response{Header: header})
+
+		adjustment := "Approaching rate limit (legacy headers), being more conservative"
+		assert.True(t, containsLogEntry(t, logs.String(), "info", adjustment))
+		assert.False(t, containsLogEntry(t, logs.String(), "warn", adjustment))
+		assert.True(t, containsLogEntry(t, logs.String(), "debug", "Rate limit will reset, scheduling next request"))
+	})
 }
 
 func TestRateLimitBuckets(t *testing.T) {
@@ -633,7 +715,7 @@ func TestWithRateLimitHeaders(t *testing.T) {
 			check: func(t *testing.T, rl *RateLimiter) {
 				rl.mu.RLock()
 				defer rl.mu.RUnlock()
-				
+
 				// Rate should be adjusted based on remaining requests and time
 				// The exact value depends on the rate limiter's internal calculations
 				assert.Greater(t, rl.rate, 0*time.Second)
@@ -648,7 +730,7 @@ func TestWithRateLimitHeaders(t *testing.T) {
 			check: func(t *testing.T, rl *RateLimiter) {
 				rl.mu.RLock()
 				defer rl.mu.RUnlock()
-				
+
 				// Should set a backoff for the retry-after duration
 				assert.False(t, rl.backoffUntil.IsZero())
 			},
@@ -686,7 +768,7 @@ func TestWithRateLimitHeaders(t *testing.T) {
 				// No rate limiting should be applied
 				rl.mu.RLock()
 				defer rl.mu.RUnlock()
-				
+
 				// Should keep the original rate
 				assert.Equal(t, 100*time.Millisecond, rl.rate)
 			},

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -509,6 +509,12 @@ func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
 	assert.Equal(t, uint64(2), rl.GetMetrics().RateLimited)
 
 	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusOK, Header: http.Header{}})
+	assert.Equal(t, 400*time.Millisecond, rl.GetRate())
+
+	healthyHeaders := make(http.Header)
+	healthyHeaders.Set("X-RateLimit-Limit", "100")
+	healthyHeaders.Set("X-RateLimit-Remaining", "90")
+	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusOK, Header: healthyHeaders})
 	assert.Equal(t, 100*time.Millisecond, rl.GetRate())
 }
 

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -447,36 +447,51 @@ func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
 	serverDelay := time.Duration(serverDelaySeconds) * time.Second
 	require.Greater(t, serverDelay, DefaultMaxBackoff)
 
+	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+		"Retry-After": {strconv.Itoa(serverDelaySeconds)},
+	}})
+
+	rl.mu.RLock()
+	pause := rl.checkBackoff()
+	rl.mu.RUnlock()
+
+	assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
+	assert.LessOrEqual(t, pause, DefaultMaxBackoff)
+}
+
+func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 	tests := []struct {
-		name string
-		resp *http.Response
+		name               string
+		serverDelaySeconds int
+		expectedPause      time.Duration
 	}{
 		{
-			name: "Retry-After",
-			resp: &http.Response{Header: http.Header{
-				"Retry-After": {strconv.Itoa(serverDelaySeconds)},
-			}},
+			name:               "waits beyond ordinary backoff cap",
+			serverDelaySeconds: int((DefaultMaxBackoff + time.Minute) / time.Second),
+			expectedPause:      DefaultMaxBackoff + time.Minute,
 		},
 		{
-			name: "exhausted daily IETF reset",
-			resp: &http.Response{Header: http.Header{
-				"Ratelimit":        {fmt.Sprintf(`"daily";r=0;t=%d`, serverDelaySeconds)},
-				"Ratelimit-Policy": {`"daily";q=5000;w=86400`},
-			}},
+			name:               "caps maximum integer without overflowing",
+			serverDelaySeconds: int(^uint(0) >> 1),
+			expectedPause:      DefaultMaxDailyResetWait,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
-			rl.WithRateLimitHeaders(tt.resp)
+			rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
+				"Ratelimit":        {fmt.Sprintf(`"daily";r=0;t=%d`, tt.serverDelaySeconds)},
+				"Ratelimit-Policy": {`"daily";q=5000;w=86400`},
+			}})
 
 			rl.mu.RLock()
 			pause := rl.checkBackoff()
 			rl.mu.RUnlock()
 
-			assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
-			assert.LessOrEqual(t, pause, DefaultMaxBackoff)
+			assert.Greater(t, pause, tt.expectedPause-time.Second)
+			assert.LessOrEqual(t, pause, tt.expectedPause)
 		})
 	}
 }

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -54,7 +54,7 @@ func init() {
 func TestRateLimiter_ContextCancellation(t *testing.T) {
 	t.Run("context canceled", func(t *testing.T) {
 		log := setupTestLogger(t)
-		rl := NewRateLimiter(100*time.Millisecond, 1, 5, log)
+		rl := NewRateLimiter(100*time.Millisecond, 5, log)
 
 		// Create a context with timeout
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -71,7 +71,7 @@ func TestRateLimiter_ConcurrentWaitsArePaced(t *testing.T) {
 		interval      = 15 * time.Millisecond
 		totalRequests = 5
 	)
-	rl := NewRateLimiter(interval, 1, 2, setupTestLogger(t))
+	rl := NewRateLimiter(interval, 2, setupTestLogger(t))
 	start := make(chan struct{})
 	type result struct {
 		completedAt time.Time
@@ -104,7 +104,7 @@ func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
 		interval = 100 * time.Millisecond
 		backoff  = 160 * time.Millisecond
 	)
-	rl := NewRateLimiter(interval, 1, 2, setupTestLogger(t))
+	rl := NewRateLimiter(interval, 2, setupTestLogger(t))
 	type result struct {
 		completedAt time.Time
 		err         error
@@ -130,7 +130,7 @@ func TestRateLimiter_PendingWaitObservesNewBackoff(t *testing.T) {
 
 func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 	const interval = 80 * time.Millisecond
-	rl := NewRateLimiter(interval, 1, 3, setupTestLogger(t))
+	rl := NewRateLimiter(interval, 3, setupTestLogger(t))
 	type result struct {
 		completedAt time.Time
 		err         error
@@ -170,7 +170,7 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 }
 
 func TestRateLimiter_OnRateLimit(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	waitTime := rl.OnRateLimit(10 * time.Second)
@@ -181,7 +181,7 @@ func TestRateLimiter_OnRateLimit(t *testing.T) {
 }
 
 func TestRateLimiter_ResetRate(t *testing.T) {
-	rl := NewRateLimiter(time.Second, 1, 1, nil)
+	rl := NewRateLimiter(time.Second, 1, nil)
 	rl.SetBackoffFactor(2)
 	rl.SetJitterFactor(0)
 
@@ -197,7 +197,7 @@ func TestRateLimiter_ResetRate(t *testing.T) {
 }
 
 func TestRateLimiter_GetMetrics(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	// Initial metrics
@@ -216,7 +216,7 @@ func TestRateLimiter_GetMetrics(t *testing.T) {
 }
 
 func TestRateLimiter_SetBackoffFactor(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	// Set backoff factor
@@ -229,7 +229,7 @@ func TestRateLimiter_SetBackoffFactor(t *testing.T) {
 }
 
 func TestRateLimiter_SetJitterFactor(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	// Set jitter factor
@@ -242,7 +242,7 @@ func TestRateLimiter_SetJitterFactor(t *testing.T) {
 }
 
 func TestRateLimiter_CheckBackoff(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	// No backoff initially
@@ -265,7 +265,7 @@ func TestRateLimiter_CheckBackoff(t *testing.T) {
 }
 
 func TestRateLimiter_CalculateJitter(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
 
 	// Test with default jitter factor
@@ -413,7 +413,7 @@ func TestParseIETFRateLimitPolicy(t *testing.T) {
 
 func TestRateLimiterWaitDoesNotAccelerate(t *testing.T) {
 	const interval = 15 * time.Millisecond
-	rl := NewRateLimiter(interval, 1, 1, nil)
+	rl := NewRateLimiter(interval, 1, nil)
 
 	var previous time.Time
 	for range 6 {
@@ -428,7 +428,7 @@ func TestRateLimiterWaitDoesNotAccelerate(t *testing.T) {
 
 func TestRateLimiterIETFZeroResetDoesNotCreatePermanentBackoff(t *testing.T) {
 	configuredRate := 2 * time.Second
-	rl := NewRateLimiter(configuredRate, 1, 1, nil)
+	rl := NewRateLimiter(configuredRate, 1, nil)
 	resp := &http.Response{Header: http.Header{
 		"Ratelimit":        {`"Free";r=1;t=0`},
 		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
@@ -447,7 +447,7 @@ func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
 	serverDelay := time.Duration(serverDelaySeconds) * time.Second
 	require.Greater(t, serverDelay, DefaultMaxBackoff)
 
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
 		"Retry-After": {strconv.Itoa(serverDelaySeconds)},
 	}})
@@ -480,7 +480,7 @@ func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 			rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
 				"Ratelimit":        {fmt.Sprintf(`"daily";r=0;t=%d`, tt.serverDelaySeconds)},
 				"Ratelimit-Policy": {`"daily";q=5000;w=86400`},
@@ -497,7 +497,7 @@ func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 }
 
 func TestRateLimiterUsesPolicyWindowForSteadyPacing(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
 		"Ratelimit":        {`"Free";r=8;t=42`},
 		"Ratelimit-Policy": {`"Free";q=60;w=60;burst=10`},
@@ -507,7 +507,7 @@ func TestRateLimiterUsesPolicyWindowForSteadyPacing(t *testing.T) {
 }
 
 func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	rl.SetBackoffFactor(2)
 	rl.SetJitterFactor(0)
 
@@ -534,7 +534,7 @@ func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
 }
 
 func TestRateLimiterUnguided429PreservesLongerBackoff(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	rl.SetBackoffFactor(2)
 	rl.SetJitterFactor(0)
 
@@ -597,7 +597,7 @@ func TestRateLimiterFallsBackForUnguidedTooManyRequests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 			rl.SetBackoffFactor(2)
 			rl.SetJitterFactor(0)
 
@@ -650,7 +650,7 @@ func TestRateLimiterHonorsAuthoritativeTooManyRequestsGuidance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+			rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 			rl.SetBackoffFactor(2)
 			rl.SetJitterFactor(0)
 			rl.WithRateLimitHeaders(&http.Response{
@@ -671,7 +671,7 @@ func TestRateLimiterRecoversFromHeaderDrivenSlowdown(t *testing.T) {
 	configuredRate := 2 * time.Second
 	var logs bytes.Buffer
 	testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.InfoLevel)}
-	rl := NewRateLimiter(configuredRate, 1, 1, testLogger)
+	rl := NewRateLimiter(configuredRate, 1, testLogger)
 
 	rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
 		"Ratelimit":        {`"Free";r=8;t=42, "daily";r=1;t=10`},
@@ -701,7 +701,7 @@ func TestRateLimiterAdaptivePacingLogLevels(t *testing.T) {
 	t.Run("IETF window adjustment is info", func(t *testing.T) {
 		var logs bytes.Buffer
 		testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.DebugLevel)}
-		rl := NewRateLimiter(100*time.Millisecond, 1, 1, testLogger)
+		rl := NewRateLimiter(100*time.Millisecond, 1, testLogger)
 		logs.Reset()
 
 		rl.WithRateLimitHeaders(&http.Response{Header: http.Header{
@@ -717,7 +717,7 @@ func TestRateLimiterAdaptivePacingLogLevels(t *testing.T) {
 	t.Run("legacy adjustment is info and reset schedule is debug", func(t *testing.T) {
 		var logs bytes.Buffer
 		testLogger := &logger.Logger{Logger: zerolog.New(&logs).Level(zerolog.DebugLevel)}
-		rl := NewRateLimiter(100*time.Millisecond, 1, 1, testLogger)
+		rl := NewRateLimiter(100*time.Millisecond, 1, testLogger)
 		logs.Reset()
 
 		header := make(http.Header)
@@ -834,7 +834,7 @@ func TestWithRateLimitHeaders(t *testing.T) {
 				TimeFormat: time.RFC3339,
 			})
 			log := logger.Get().With(map[string]interface{}{"test": tt.name})
-			rl := NewRateLimiter(100*time.Millisecond, 10, 1, log)
+			rl := NewRateLimiter(100*time.Millisecond, 1, log)
 			defer rl.ResetRate()
 
 			// Create a response with headers and a valid Request

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -833,6 +833,7 @@ func TestRateLimiterHonorsAuthoritativeTooManyRequestsGuidance(t *testing.T) {
 			})
 
 			assert.Equal(t, tt.expectedRate, rl.GetRate())
+			assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
 			rl.mu.RLock()
 			assert.Greater(t, rl.checkBackoff(), time.Duration(0))
 			rl.mu.RUnlock()

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -430,7 +430,7 @@ func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
 	}})
 
 	rl.mu.RLock()
-	pause := rl.backoffUntil.Sub(time.Now())
+	pause := time.Until(rl.backoffUntil)
 	rl.mu.RUnlock()
 
 	assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
@@ -452,7 +452,7 @@ func TestRateLimiterDailyExhaustionOverridesRetryAfter(t *testing.T) {
 	})
 
 	rl.mu.RLock()
-	pause := rl.backoffUntil.Sub(time.Now())
+	pause := time.Until(rl.backoffUntil)
 	rl.mu.RUnlock()
 	assert.Greater(t, pause, DefaultMaxBackoff)
 	assert.LessOrEqual(t, pause, DefaultMaxDailyResetWait)
@@ -488,7 +488,7 @@ func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 			}})
 
 			rl.mu.RLock()
-			pause := rl.backoffUntil.Sub(time.Now())
+			pause := time.Until(rl.backoffUntil)
 			rl.mu.RUnlock()
 
 			assert.Greater(t, pause, tt.expectedPause-time.Second)

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -241,29 +241,6 @@ func TestRateLimiter_SetJitterFactor(t *testing.T) {
 	rl.mu.RUnlock()
 }
 
-func TestRateLimiter_CheckBackoff(t *testing.T) {
-	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
-	defer rl.ResetRate()
-
-	// No backoff initially
-	rl.mu.RLock()
-	remaining := rl.checkBackoff()
-	rl.mu.RUnlock()
-	assert.Equal(t, time.Duration(0), remaining)
-
-	// Set a backoff
-	rl.mu.Lock()
-	rl.backoffUntil = time.Now().Add(100 * time.Millisecond)
-	rl.mu.Unlock()
-
-	// Should return remaining backoff time
-	rl.mu.RLock()
-	remaining = rl.checkBackoff()
-	rl.mu.RUnlock()
-	assert.Greater(t, remaining, time.Duration(0))
-	assert.LessOrEqual(t, remaining, 100*time.Millisecond)
-}
-
 func TestRateLimiter_CalculateJitter(t *testing.T) {
 	rl := NewRateLimiter(100*time.Millisecond, 1, nil)
 	defer rl.ResetRate()
@@ -439,7 +416,7 @@ func TestRateLimiterIETFZeroResetDoesNotCreatePermanentBackoff(t *testing.T) {
 	assert.Equal(t, configuredRate, rl.GetRate())
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()
-	assert.Zero(t, rl.checkBackoff())
+	assert.Zero(t, rl.backoffUntil)
 }
 
 func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
@@ -453,7 +430,7 @@ func TestRateLimiterCapsServerPauseAtDefaultMaxBackoff(t *testing.T) {
 	}})
 
 	rl.mu.RLock()
-	pause := rl.checkBackoff()
+	pause := rl.backoffUntil.Sub(time.Now())
 	rl.mu.RUnlock()
 
 	assert.Greater(t, pause, DefaultMaxBackoff-time.Second)
@@ -487,7 +464,7 @@ func TestRateLimiterWaitsForDailyQuotaReset(t *testing.T) {
 			}})
 
 			rl.mu.RLock()
-			pause := rl.checkBackoff()
+			pause := rl.backoffUntil.Sub(time.Now())
 			rl.mu.RUnlock()
 
 			assert.Greater(t, pause, tt.expectedPause-time.Second)
@@ -516,7 +493,7 @@ func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
 	assert.Equal(t, 200*time.Millisecond, rl.GetRate())
 	assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
 	rl.mu.RLock()
-	assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+	assert.True(t, rl.backoffUntil.After(time.Now()))
 	rl.mu.RUnlock()
 
 	rl.WithRateLimitHeaders(&http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}})
@@ -609,7 +586,7 @@ func TestRateLimiterFallsBackForUnguidedTooManyRequests(t *testing.T) {
 			assert.Equal(t, 200*time.Millisecond, rl.GetRate())
 			assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
 			rl.mu.RLock()
-			assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+			assert.True(t, rl.backoffUntil.After(time.Now()))
 			rl.mu.RUnlock()
 		})
 	}
@@ -661,7 +638,7 @@ func TestRateLimiterHonorsAuthoritativeTooManyRequestsGuidance(t *testing.T) {
 			assert.Equal(t, tt.expectedRate, rl.GetRate())
 			assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
 			rl.mu.RLock()
-			assert.Greater(t, rl.checkBackoff(), time.Duration(0))
+			assert.True(t, rl.backoffUntil.After(time.Now()))
 			rl.mu.RUnlock()
 		})
 	}

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -181,18 +181,18 @@ func TestRateLimiter_OnRateLimit(t *testing.T) {
 }
 
 func TestRateLimiter_ResetRate(t *testing.T) {
-	// Create a rate limiter with a custom rate
 	rl := NewRateLimiter(time.Second, 1, 1, nil)
+	rl.SetBackoffFactor(2)
+	rl.SetJitterFactor(0)
 
-	// Modify the rate to something different
-	rl.mu.Lock()
-	rl.rate = 5 * time.Second
-	rl.mu.Unlock()
+	rl.WithRateLimitHeaders(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+	})
+	require.Equal(t, 2*time.Second, rl.GetRate())
 
-	// Reset the rate
 	rl.ResetRate()
 
-	// Should be back to the rate configured for this limiter.
 	assert.Equal(t, time.Second, rl.GetRate())
 }
 

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -169,77 +169,15 @@ func TestRateLimiter_CancellationDoesNotCollapsePendingSlots(t *testing.T) {
 		"cancellation allowed two pending waiters into the same pacing slot")
 }
 
-const (
-	// Default backoff factor for testing
-	testDefaultBackoffFactor = 8.0 // This matches the default in the implementation
-
-	// Default jitter factor for testing (0.0 to disable jitter)
-	testDefaultJitterFactor = 0.0
-)
-
 func TestRateLimiter_OnRateLimit(t *testing.T) {
-	// Create a rate limiter with test values
 	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
 	defer rl.ResetRate()
 
-	// Set test values for backoff and jitter
-	rl.SetBackoffFactor(testDefaultBackoffFactor)
-	rl.SetJitterFactor(testDefaultJitterFactor)
+	waitTime := rl.OnRateLimit(10 * time.Second)
 
-	tests := []struct {
-		name       string
-		retryAfter time.Duration
-		setup      func(rl *RateLimiter)
-		check      func(t *testing.T, waitTime time.Duration, rl *RateLimiter)
-	}{
-		{
-			name:       "short retry with default backoff",
-			retryAfter: 100 * time.Millisecond,
-			setup: func(rl *RateLimiter) {
-				// No special setup needed for this test case
-			},
-			check: func(t *testing.T, waitTime time.Duration, rl *RateLimiter) {
-				assert.Equal(t, 100*time.Millisecond, waitTime)
-				assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must not permanently change request pacing")
-
-				// Verify metrics
-				metrics := rl.GetMetrics()
-				assert.Equal(t, uint64(1), metrics.RateLimited)
-			},
-		},
-		{
-			name:       "long retry with backoff",
-			retryAfter: 10 * time.Second,
-			setup: func(rl *RateLimiter) {
-				// Set a custom backoff factor for this test
-				rl.SetBackoffFactor(1.5)
-			},
-			check: func(t *testing.T, waitTime time.Duration, rl *RateLimiter) {
-				assert.Equal(t, 10*time.Second, waitTime)
-				assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must remain a temporary pause")
-
-				// Verify metrics
-				metrics := rl.GetMetrics()
-				assert.Equal(t, uint64(1), metrics.RateLimited)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
-			defer rl.ResetRate()
-
-			// Apply any test-specific setup
-			if tt.setup != nil {
-				tt.setup(rl)
-			}
-
-			// Call OnRateLimit and verify the result
-			waitTime := rl.OnRateLimit(tt.retryAfter)
-			tt.check(t, waitTime, rl)
-		})
-	}
+	assert.Equal(t, 10*time.Second, waitTime)
+	assert.Equal(t, 100*time.Millisecond, rl.GetRate(), "Retry-After must remain a temporary pause")
+	assert.Equal(t, uint64(1), rl.GetMetrics().RateLimited)
 }
 
 func TestRateLimiter_ResetRate(t *testing.T) {

--- a/internal/util/rate_limiter_test.go
+++ b/internal/util/rate_limiter_test.go
@@ -733,6 +733,32 @@ func TestRateLimiterFallsBackForBareTooManyRequests(t *testing.T) {
 	assert.Equal(t, 100*time.Millisecond, rl.GetRate())
 }
 
+func TestRateLimiterUnguided429PreservesLongerBackoff(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, 1, nil)
+	rl.SetBackoffFactor(2)
+	rl.SetJitterFactor(0)
+
+	rl.WithRateLimitHeaders(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": {"2"}},
+	})
+	rl.mu.RLock()
+	authoritativeDeadline := rl.backoffUntil
+	rl.mu.RUnlock()
+
+	rl.WithRateLimitHeaders(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+	})
+
+	assert.Equal(t, 200*time.Millisecond, rl.GetRate(), "bare 429 should still escalate steady pacing")
+	assert.Equal(t, uint64(2), rl.GetMetrics().RateLimited, "each 429 should count")
+	rl.mu.RLock()
+	actualDeadline := rl.backoffUntil
+	rl.mu.RUnlock()
+	assert.Equal(t, authoritativeDeadline, actualDeadline, "shorter fallback must not replace authoritative backoff")
+}
+
 func TestRateLimiterFallsBackForUnguidedTooManyRequests(t *testing.T) {
 	reset := strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
 	tests := []struct {


### PR DESCRIPTION
## Summary

Corrects Hardcover request pacing, concurrency, and recovery so syncs respond predictably to rate-limit guidance without appearing stalled or sending requests too quickly. The limiter now distinguishes normal pacing, temporary server-directed pauses, daily quota exhaustion, and fallback backoff.

## What Changed

- Pace sequential and concurrent requests consistently, including queued and canceled requests
- Hold concurrency permits for the full HTTP request and apply response guidance before admitting queued work
- Remove a duplicate rate-limit wait from publisher searches so each HTTP request is admitted and counted once
- Honor valid `Retry-After` values and quota reset windows as temporary pauses
- Wait until the reported reset when the daily quota is exhausted, with a separate 24-hour safety cap
- Apply bounded exponential backoff to bare, partial, or malformed 429 responses without shortening a longer existing pause
- Cap ordinary pauses and adaptive pacing at `DefaultMaxBackoff`
- Calculate sustainable pacing from IETF and legacy quota headers
- Restore the configured request rate when healthy quota data returns, while preserving elevated pacing when no quota data is available
- Count every 429 response once and clarify logs for throttling, adaptive pacing, recovery, and reset scheduling
- Remove the unused token-bucket implementation and obsolete burst setting from application configuration, examples, Helm values, and documentation
- Add migration guidance for removing `RATE_LIMIT_BURST` and `rate_limit.burst`
- Consolidate rate-limiter tests around observable pacing, concurrency, cancellation, backoff, reset, recovery, metrics, and logging behavior

## Why

The previous limiter could let concurrent requests accelerate the configured pace, release capacity before a request completed, and recover inconsistently after throttling. Some 429 responses could also bypass useful backoff or replace a longer server-directed pause with a shorter fallback delay.

These changes centralize request admission, keep all waits bounded, honor authoritative reset information, and recover only when the response provides evidence that normal pacing is safe.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

## Checklist

- [x] Tests pass locally
- [x] Tests pass on CI
- [x] Code quality checks pass on CI
- [x] Documentation is updated
- [x] Changelog is updated
