### PR TITLE
fix(web): make Sync Status refresh unobtrusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Make sync status refresh unobtrusive**: Make Sync Status polling quiet and race safe so background refreshes do not flash the page or disturb the user's current view. By @Snuffy2.
 - **Sync Status fetch errors**: Remove misplaced Hardcover mismatch-display code from status loading so successful profile status requests no longer log an undefined-variable error by @Snuffy2. (#178)
 - **Limit raw API response logging to debug**: Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. (#174)
 - **Prevent Hardcover mutations during dry runs**: dry_run was not working correctly. Prevent dry-run syncs from calling Hardcover mutation APIs while preserving the read operations needed to report intended changes, and identify active dry runs on the Sync Status page. (#175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Make sync status refresh unobtrusive**: Make Sync Status polling quiet and race safe so background refreshes do not flash the page or disturb the user's current view. Automatically retry a failed initial profile load without requiring a manual refresh. By @Snuffy2.
+- **Make sync status refresh unobtrusive**: Make Sync Status polling quiet and race safe so background refreshes do not flash the page or disturb the user's current view. Automatically retry a failed initial profile load without requiring a manual refresh. By @Snuffy2. (#180)
 - **Sync Status fetch errors**: Remove misplaced Hardcover mismatch-display code from status loading so successful profile status requests no longer log an undefined-variable error by @Snuffy2. (#178)
 - **Limit raw API response logging to debug**: Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. (#174)
 - **Prevent Hardcover mutations during dry runs**: dry_run was not working correctly. Prevent dry-run syncs from calling Hardcover mutation APIs while preserving the read operations needed to report intended changes, and identify active dry runs on the Sync Status page. (#175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Make sync status refresh unobtrusive**: Make Sync Status polling quiet and race safe so background refreshes do not flash the page or disturb the user's current view. By @Snuffy2.
+- **Make sync status refresh unobtrusive**: Make Sync Status polling quiet and race safe so background refreshes do not flash the page or disturb the user's current view. Automatically retry a failed initial profile load without requiring a manual refresh. By @Snuffy2.
 - **Sync Status fetch errors**: Remove misplaced Hardcover mismatch-display code from status loading so successful profile status requests no longer log an undefined-variable error by @Snuffy2. (#178)
 - **Limit raw API response logging to debug**: Routes the full Audiobookshelf library-items API response through debug logging instead of writing it directly to standard error. (#174)
 - **Prevent Hardcover mutations during dry runs**: dry_run was not working correctly. Prevent dry-run syncs from calling Hardcover mutation APIs while preserving the read operations needed to report intended changes, and identify active dry runs on the Sync Status page. (#175)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Automatically syncs your Audiobookshelf library with Hardcover, including readin
 - **👥 Multiple Sync Profiles**: Each profile can have individual Audiobookshelf and Hardcover tokens
 - **🔒 Secure Storage**: All API tokens encrypted at rest with AES-256-GCM
 - **🔄 Concurrent Syncing**: Multiple profiles can sync simultaneously
-- **📊 Real-Time Monitoring**: Live sync status with auto-refresh
+- **📊 Real-Time Monitoring**: Live sync status with quiet auto-refresh and automatic retry after a temporary profile-load failure
 - **🔧 REST API**: Complete programmatic control via RESTful endpoints
 - **⬆️ Automatic Migration**: Seamless upgrade from single-profile setups
 - **🔙 Backwards Compatible**: All existing functionality preserved
@@ -156,7 +156,7 @@ The project follows standard Go project layout:
 - **🌐 Web Interface**: Modern, responsive management dashboard at `http://localhost:8080`
 - **🔒 Secure Storage**: AES-256-GCM encrypted token storage
 - **🔄 Concurrent Syncing**: Multiple users can sync simultaneously
-- **📊 Real-Time Monitoring**: Live sync status with auto-refresh
+- **📊 Real-Time Monitoring**: Live sync status with quiet auto-refresh and automatic retry after a temporary profile-load failure
 - **🔧 REST API**: Complete programmatic control via RESTful endpoints
 - **⬆️ Automatic Migration**: Seamless upgrade from single-user setups
 - **🔙 Backwards Compatible**: All existing functionality preserved

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -39,6 +39,7 @@ class SyncProfileApp {
         this.activeStatusLoads = 0;
         this.activeStatusRequests = 0;
         this.statusLoadController = null;
+        this.profileLoadFailed = false;
         
         this.init();
     }
@@ -111,8 +112,8 @@ class SyncProfileApp {
                 // before fetching their statuses.
                 await this.loadStatuses();
                 
-                // Start auto-refresh only if we have data to refresh
-                if (this.users.length > 0) {
+                // Keep retrying if the initial profile request failed.
+                if (this.users.length > 0 || this.profileLoadFailed) {
                     this.startAutoRefresh();
                 }
             } catch (error) {
@@ -518,6 +519,7 @@ class SyncProfileApp {
             
             // Check authentication status first
             if (this.authEnabled && !this.currentUser) {
+                this.profileLoadFailed = false;
                 this.showToast('Please log in to view profiles', 'error');
                 this.redirectToLogin();
                 return;
@@ -534,25 +536,30 @@ class SyncProfileApp {
             
             // Handle authentication errors specifically
             if (response.status === 401 || response.status === 403) {
+                this.profileLoadFailed = false;
                 this.showToast('Authentication required. Please log in.', 'error');
                 this.redirectToLogin();
                 return;
             }
             
             if (response.ok && data.success) {
+                this.profileLoadFailed = false;
                 this.users = data.data;
                 this.renderProfiles();
             } else {
                 // Handle different types of errors
                 if (data.error && data.error.code === 'authentication_required') {
+                    this.profileLoadFailed = false;
                     this.showToast('Authentication required. Please log in.', 'error');
                     this.redirectToLogin();
                 } else {
-                    this.showToast('Failed to load sync profiles: ' + (data.error?.message || data.error || 'Unknown error'), 'error');
+                    const message = 'Failed to load sync profiles: ' + (data.error?.message || data.error || 'Unknown error');
+                    if (statusOwned) throw new Error(message);
+                    this.showToast(message, 'error');
                 }
             }
         } catch (error) {
-            if (statusOwned && (error.name === 'AbortError' || error.name === 'TimeoutError')) throw error;
+            if (statusOwned) throw error;
             this.showToast('Error loading sync profiles: ' + error.message, 'error');
         } finally {
             if (showLoading) this.hideLoading();
@@ -653,6 +660,11 @@ class SyncProfileApp {
             
         } catch (error) {
             console.error('Error in loadStatuses:', error);
+            if (this.users.length === 0 && requestSequence === this.statusLoadSequence && error.name !== 'AbortError') {
+                this.profileLoadFailed = true;
+                this.renderStatuses({ unavailable: true });
+                this.startAutoRefresh();
+            }
             if (!silent && requestSequence === this.statusLoadSequence && error.name !== 'AbortError') {
                 this.showToast('Error loading statuses: ' + error.message, 'error');
             }
@@ -2293,7 +2305,8 @@ class SyncProfileApp {
 
         // Refresh statuses every 5 seconds
         this.refreshInterval = setInterval(() => {
-            if (this.autoRefreshEnabled && document.getElementById('sync-tab').classList.contains('active')) {
+            if (this.autoRefreshEnabled &&
+                (this.profileLoadFailed || document.getElementById('sync-tab').classList.contains('active'))) {
                 if (this.activeStatusRequests > 0) return;
                 this.loadStatuses({ silent: true });
             }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -637,7 +637,6 @@ class SyncProfileApp {
             }
         } catch (error) {
             console.error(`Error fetching summary for profile ${profileId}:`, error);
-            if (error.name === 'AbortError') return;
             // Don't show toast here to avoid multiple toasts for multiple failures
         }
     }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -653,7 +653,7 @@ class SyncProfileApp {
                     </div>
                     <div class="status-info">
                         ${lastSync ? `
-                            <div><strong>Last Sync:</strong> <span title="${new Date(lastSync).toLocaleString()}">${this.formatRelativeTime(lastSync)}</span></div>
+                            <div><strong>Last Sync:</strong> <span class="relative-sync-time" data-sync-timestamp="${this.escapeHtml(lastSync)}" title="${new Date(lastSync).toLocaleString()}">${this.formatRelativeTime(lastSync)}</span></div>
                         ` : ''}
                         ${progress > 0 ? `
                             <div><strong>Progress:</strong> ${progress}%</div>
@@ -707,14 +707,23 @@ class SyncProfileApp {
         }
     }
 
+    updateRelativeSyncTime(card, lastSync) {
+        const relativeTime = card.querySelector('.relative-sync-time');
+        if (!relativeTime || !lastSync) return;
+
+        relativeTime.dataset.syncTimestamp = lastSync;
+        relativeTime.textContent = this.formatRelativeTime(lastSync);
+        relativeTime.title = new Date(lastSync).toLocaleString();
+    }
+
     renderStatuses() {
         const container = document.getElementById('sync-status');
         if (!container) return;
 
         if (Object.keys(this.statuses).length === 0) {
-            if (!container.querySelector('.status-card')) {
+            if (!container.querySelector('.status-empty-state')) {
                 container.innerHTML = `
-                    <div class="text-center" style="grid-column: 1 / -1; padding: 40px;">
+                    <div class="text-center status-empty-state" style="grid-column: 1 / -1; padding: 40px;">
                         <h3>No sync statuses available</h3>
                         <p>Add a new sync profile and start syncing to see status information.</p>
                     </div>
@@ -772,6 +781,7 @@ class SyncProfileApp {
             }
 
             retainedProfiles.add(profileId);
+            this.updateRelativeSyncTime(card, status.last_sync || status.lastSync);
             const cardAtPosition = container.children[index];
             if (cardAtPosition !== card) {
                 container.insertBefore(card, cardAtPosition || null);

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -38,6 +38,7 @@ class SyncProfileApp {
         this.statusLoadSequence = 0;
         this.activeStatusLoads = 0;
         this.activeStatusRequests = 0;
+        this.statusLoadController = null;
         
         this.init();
     }
@@ -341,6 +342,28 @@ class SyncProfileApp {
     }
 
     setupEventListeners() {
+        const bindProfileActions = (containerId, cardSelector) => {
+            const container = document.getElementById(containerId);
+            container.addEventListener('click', (event) => {
+                const button = event.target.closest('button[data-profile-action]');
+                if (!button || !container.contains(button)) return;
+
+                const card = button.closest(cardSelector);
+                if (!card || !container.contains(card)) return;
+                const profileId = card.dataset.profileId;
+
+                switch (button.dataset.profileAction) {
+                    case 'edit': this.editProfile(profileId); break;
+                    case 'delete': this.deleteProfile(profileId); break;
+                    case 'start': this.startSync(profileId); break;
+                    case 'cancel': this.cancelSync(profileId); break;
+                    case 'summary': this.showSyncSummary(profileId); break;
+                }
+            });
+        };
+        bindProfileActions('users-list', '.user-card[data-profile-id]');
+        bindProfileActions('sync-status', '.status-card[data-profile-id]');
+
         // Tab switching
         document.querySelectorAll('.tab-button').forEach(button => {
             button.addEventListener('click', (e) => {
@@ -410,7 +433,7 @@ class SyncProfileApp {
             const statusIcon = user.active ? '✓' : '✗';
             
             return `
-                <div class="user-card">
+                <div class="user-card" data-profile-id="${this.escapeHtml(user.id)}">
                     <div class="user-card-header">
                         <h3>${this.escapeHtml(user.name || user.id)}</h3>
                         <span class="status-badge ${statusClass}" title="${user.active ? 'Active' : 'Inactive'}">
@@ -431,13 +454,13 @@ class SyncProfileApp {
                         </div>
                         
                         <div class="user-card-actions">
-                            <button class="btn btn-sm btn-icon" onclick="app.editProfile('${this.escapeHtml(user.id)}')" title="Edit Profile">
+                            <button class="btn btn-sm btn-icon" data-profile-action="edit" title="Edit Profile">
                                 <span class="icon">✏️</span> Edit
                             </button>
-                            <button class="btn btn-sm btn-icon btn-danger" onclick="app.deleteProfile('${this.escapeHtml(user.id)}')" title="Delete Profile">
+                            <button class="btn btn-sm btn-icon btn-danger" data-profile-action="delete" title="Delete Profile">
                                 <span class="icon">🗑️</span> Delete
                             </button>
-                            <button class="btn btn-sm btn-primary" onclick="app.startSync('${this.escapeHtml(user.id)}')" ${user.active ? '' : 'disabled'}>
+                            <button class="btn btn-sm btn-primary" data-profile-action="start" ${user.active ? '' : 'disabled'}>
                                 <span class="icon">🔄</span> Sync Now
                             </button>
                         </div>
@@ -448,11 +471,21 @@ class SyncProfileApp {
     }
 
     async fetchJsonWithTimeout(url, options = {}) {
+        const { signal: requestSignal, ...fetchOptions } = options;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), STATUS_LOAD_TIMEOUT_MS);
+        const abortForRequest = () => controller.abort(requestSignal.reason);
+
+        if (requestSignal) {
+            if (requestSignal.aborted) {
+                abortForRequest();
+            } else {
+                requestSignal.addEventListener('abort', abortForRequest, { once: true });
+            }
+        }
 
         try {
-            const response = await fetch(url, { ...options, signal: controller.signal });
+            const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
             const data = await response.json();
             if (controller.signal.aborted) {
                 const error = new Error('Request timed out');
@@ -462,10 +495,11 @@ class SyncProfileApp {
             return { response, data };
         } finally {
             clearTimeout(timeout);
+            requestSignal?.removeEventListener('abort', abortForRequest);
         }
     }
 
-    async loadProfiles({ showLoading = true, statusOwned = false } = {}) {
+    async loadProfiles({ showLoading = true, statusOwned = false, signal } = {}) {
         try {
             if (showLoading) this.showLoading();
             
@@ -481,7 +515,8 @@ class SyncProfileApp {
                 credentials: 'include', // Include session cookies
                 headers: {
                     'Content-Type': 'application/json'
-                }
+                },
+                signal
             });
             
             // Handle authentication errors specifically
@@ -513,6 +548,11 @@ class SyncProfileApp {
 
     async loadStatuses({ silent = false } = {}) {
         const requestSequence = ++this.statusLoadSequence;
+        this.statusLoadController?.abort();
+        const controller = new AbortController();
+        this.statusLoadController = controller;
+        const { signal } = controller;
+        const isCurrentRequest = () => requestSequence === this.statusLoadSequence && !signal.aborted;
         this.activeStatusRequests += 1;
         try {
             if (!silent) {
@@ -526,12 +566,12 @@ class SyncProfileApp {
             if (!this.users || this.users.length === 0) {
                 // This status request owns its loading feedback. Avoid letting
                 // the nested profile request hide it before statuses finish.
-                await this.loadProfiles({ showLoading: false, statusOwned: true });
+                await this.loadProfiles({ showLoading: false, statusOwned: true, signal });
             }
             
             // If no users, render empty status
             if (!this.users || this.users.length === 0) {
-                if (requestSequence !== this.statusLoadSequence) return;
+                if (!isCurrentRequest()) return;
                 this.statuses = {};
                 this.renderStatuses();
                 return;
@@ -539,9 +579,11 @@ class SyncProfileApp {
             
             // Fetch status for each profile
             for (const user of this.users) {
+                if (!isCurrentRequest()) return;
                 try {
                     const { response: statusResponse, data: statusData } = await this.fetchJsonWithTimeout(
-                        `/api/profiles/${user.id}/status`
+                        `/api/profiles/${user.id}/status`,
+                        { signal }
                     );
                     if (statusResponse.ok) {
                         if (statusData.success) {
@@ -565,13 +607,13 @@ class SyncProfileApp {
                             
                             // Always try to fetch the summary for completed/error states
                             if (statusData.data?.state === 'completed' || statusData.data?.state === 'error') {
-                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses));
+                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses, signal));
                             }
                         }
                     }
                 } catch (error) {
                     console.error(`Error fetching status for profile ${user.id}:`, error);
-                    if (error.name === 'AbortError') {
+                    if (error.name === 'AbortError' && isCurrentRequest()) {
                         if (this.statuses[user.id]) statuses[user.id] = this.statuses[user.id];
                     }
                 }
@@ -582,7 +624,7 @@ class SyncProfileApp {
 
             // Only the newest request may publish a status snapshot. A slower
             // response from an older poll must not roll the UI back.
-            if (requestSequence !== this.statusLoadSequence) return;
+            if (!isCurrentRequest()) return;
             
             this.statuses = statuses;
             this.renderStatuses();
@@ -595,6 +637,9 @@ class SyncProfileApp {
             }
         } finally {
             this.activeStatusRequests -= 1;
+            if (this.statusLoadController === controller) {
+                this.statusLoadController = null;
+            }
             if (!silent) {
                 this.activeStatusLoads -= 1;
                 if (this.activeStatusLoads === 0) this.hideLoading();
@@ -602,10 +647,13 @@ class SyncProfileApp {
         }
     }
     
-    async fetchSyncSummary(profileId, statuses) {
+    async fetchSyncSummary(profileId, statuses, signal) {
         try {
             console.log(`Fetching sync summary for profile ${profileId}...`);
-            const { response, data: result } = await this.fetchJsonWithTimeout(`/api/profiles/${profileId}/summary`);
+            const { response, data: result } = await this.fetchJsonWithTimeout(
+                `/api/profiles/${profileId}/summary`,
+                { signal }
+            );
             if (response.ok) {
                 console.log('Raw sync summary response:', result);
                 
@@ -700,16 +748,16 @@ class SyncProfileApp {
                     </div>
                     <div class="status-actions">
                         ${statusState.toLowerCase() === 'syncing' ? `
-                            <button class="btn btn-warning" onclick="app.cancelSync('${profileId}')">
+                            <button class="btn btn-warning" data-profile-action="cancel">
                                 Cancel Sync
                             </button>
                         ` : `
-                            <button class="btn btn-primary" onclick="app.startSync('${profileId}')">
+                            <button class="btn btn-primary" data-profile-action="start">
                                 ${statusState.toLowerCase() === 'error' ? 'Retry Sync' : 'Start Sync'}
                             </button>
                         `}
                         ${hasSummary ? `
-                            <button class="btn btn-secondary" onclick="app.showSyncSummary('${profileId}')">
+                            <button class="btn btn-secondary" data-profile-action="summary">
                                 View Details
                             </button>
                         ` : ''}
@@ -766,7 +814,7 @@ class SyncProfileApp {
             let card = existingCards.get(profileId);
             const signature = JSON.stringify(status);
             const focusInfo = card && activeElement && card.contains(activeElement)
-                ? { id: activeElement.id, tagName: activeElement.tagName, onclick: activeElement.getAttribute('onclick') }
+                ? { id: activeElement.id, tagName: activeElement.tagName, action: activeElement.dataset.profileAction }
                 : null;
 
             if (!card || card.__statusSignature !== signature) {
@@ -786,9 +834,9 @@ class SyncProfileApp {
                     const focusTarget = focusInfo.id
                         ? [...card.querySelectorAll('[id]')].find(element => element.id === focusInfo.id)
                         : [...card.querySelectorAll(focusInfo.tagName)].find(element =>
-                            element.getAttribute('onclick') === focusInfo.onclick);
+                            element.dataset.profileAction === focusInfo.action);
                     const fallbackTarget = card.querySelector(
-                        '.status-actions button[onclick*="startSync"], .status-actions button[onclick*="cancelSync"]'
+                        '.status-actions button[data-profile-action="start"], .status-actions button[data-profile-action="cancel"]'
                     );
                     (focusTarget || fallbackTarget)?.focus({ preventScroll: true });
                 }
@@ -835,7 +883,7 @@ class SyncProfileApp {
         
         // Update the tabs to show the current profile
         tabsContainer.innerHTML = `
-            <button class="tab-button active" data-profile="${profileId}">
+            <button class="tab-button active" data-profile="${this.escapeHtml(profileId)}">
                 ${this.escapeHtml(status.profile_name || `Profile ${profileId}`)}
             </button>`;
         

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -433,7 +433,7 @@ class SyncProfileApp {
             const statusIcon = user.active ? '✓' : '✗';
             
             return `
-                <div class="user-card" data-profile-id="${this.escapeHtml(user.id)}">
+                <div class="user-card" data-profile-id="${this.escapeHtmlAttribute(user.id)}">
                     <div class="user-card-header">
                         <h3>${this.escapeHtml(user.name || user.id)}</h3>
                         <span class="status-badge ${statusClass}" title="${user.active ? 'Active' : 'Inactive'}">
@@ -574,6 +574,7 @@ class SyncProfileApp {
             }
             const statuses = {};
             const summaryPromises = [];
+            let failedStatuses = 0;
             
             // First, get the list of profiles if not already loaded
             if (!this.users || this.users.length === 0) {
@@ -593,6 +594,7 @@ class SyncProfileApp {
             // Fetch status for each profile
             for (const user of this.users) {
                 if (!isCurrentRequest()) return;
+                let statusLoaded = false;
                 try {
                     const { response: statusResponse, data: statusData } = await this.fetchJsonWithTimeout(
                         `/api/profiles/${user.id}/status`,
@@ -617,6 +619,7 @@ class SyncProfileApp {
                                 books_synced: statusData.data?.books_synced || 0,
                                 last_sync: statusData.data?.last_sync
                             };
+                            statusLoaded = true;
                             
                             // Always try to fetch the summary for completed/error states
                             if (statusData.data?.state === 'completed' || statusData.data?.state === 'error') {
@@ -626,9 +629,11 @@ class SyncProfileApp {
                     }
                 } catch (error) {
                     console.error(`Error fetching status for profile ${user.id}:`, error);
-                    if (error.name === 'AbortError' && isCurrentRequest()) {
-                        if (this.statuses[user.id]) statuses[user.id] = this.statuses[user.id];
-                    }
+                }
+                if (!isCurrentRequest()) return;
+                if (!statusLoaded) {
+                    failedStatuses += 1;
+                    if (this.statuses[user.id]) statuses[user.id] = this.statuses[user.id];
                 }
             }
             
@@ -640,8 +645,11 @@ class SyncProfileApp {
             if (!isCurrentRequest()) return;
             
             this.statuses = statuses;
-            this.renderStatuses();
+            this.renderStatuses({ unavailable: failedStatuses > 0 });
             this.renderSyncSummary();
+            if (failedStatuses > 0 && !silent) {
+                this.showToast(`Could not load status for ${failedStatuses} profile${failedStatuses === 1 ? '' : 's'}. Showing last known data where available.`, 'error');
+            }
             
         } catch (error) {
             console.error('Error in loadStatuses:', error);
@@ -726,7 +734,7 @@ class SyncProfileApp {
             const profileName = status.profile_name || status.profile_id || 'Unknown Profile';
 
             return `
-                <div class="status-card ${statusState.toLowerCase()}" data-profile-id="${this.escapeHtml(profileId)}">
+                <div class="status-card ${statusState.toLowerCase()}" data-profile-id="${this.escapeHtmlAttribute(profileId)}">
                     <div class="status-header">
                         <h3>${this.escapeHtml(profileName)}</h3>
                         <span class="status-badge">${this.escapeHtml(statusText)}</span>
@@ -788,19 +796,25 @@ class SyncProfileApp {
         relativeTime.title = new Date(lastSync).toLocaleString();
     }
 
-    renderStatuses() {
+    renderStatuses({ unavailable = false } = {}) {
         const container = document.getElementById('sync-status');
         if (!container) return;
 
         if (Object.keys(this.statuses).length === 0) {
-            if (!container.querySelector('.status-empty-state')) {
+            const emptyState = container.querySelector('.status-empty-state');
+            if (!emptyState) {
                 container.innerHTML = `
                     <div class="text-center status-empty-state" style="grid-column: 1 / -1; padding: 40px;">
-                        <h3>No sync statuses available</h3>
-                        <p>Add a new sync profile and start syncing to see status information.</p>
+                        <h3></h3>
+                        <p></p>
                     </div>
                 `;
             }
+            const state = container.querySelector('.status-empty-state');
+            state.querySelector('h3').textContent = unavailable ? 'Unable to load sync statuses' : 'No sync statuses available';
+            state.querySelector('p').textContent = unavailable
+                ? 'Try refreshing the status in a moment.'
+                : 'Add a new sync profile and start syncing to see status information.';
             return;
         }
 
@@ -896,7 +910,7 @@ class SyncProfileApp {
         
         // Update the tabs to show the current profile
         tabsContainer.innerHTML = `
-            <button class="tab-button active" data-profile="${this.escapeHtml(profileId)}">
+            <button class="tab-button active" data-profile="${this.escapeHtmlAttribute(profileId)}">
                 ${this.escapeHtml(status.profile_name || `Profile ${profileId}`)}
             </button>`;
         
@@ -2361,6 +2375,10 @@ class SyncProfileApp {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    escapeHtmlAttribute(text) {
+        return this.escapeHtml(text).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 }
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -473,7 +473,11 @@ class SyncProfileApp {
     async fetchJsonWithTimeout(url, options = {}) {
         const { signal: requestSignal, ...fetchOptions } = options;
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), STATUS_LOAD_TIMEOUT_MS);
+        let timedOut = false;
+        const timeout = setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+        }, STATUS_LOAD_TIMEOUT_MS);
         const abortForRequest = () => controller.abort(requestSignal.reason);
 
         if (requestSignal) {
@@ -488,11 +492,20 @@ class SyncProfileApp {
             const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
             const data = await response.json();
             if (controller.signal.aborted) {
-                const error = new Error('Request timed out');
-                error.name = 'AbortError';
+                const error = new Error(timedOut ? 'Request timed out' : 'Request aborted');
+                error.name = timedOut ? 'TimeoutError' : 'AbortError';
                 throw error;
             }
             return { response, data };
+        } catch (error) {
+            // fetch() rejects with AbortError before reaching the response path.
+            // Keep a real timeout distinct from an intentional parent cancellation.
+            if (timedOut && error.name === 'AbortError') {
+                const timeoutError = new Error('Request timed out');
+                timeoutError.name = 'TimeoutError';
+                throw timeoutError;
+            }
+            throw error;
         } finally {
             clearTimeout(timeout);
             requestSignal?.removeEventListener('abort', abortForRequest);
@@ -539,7 +552,7 @@ class SyncProfileApp {
                 }
             }
         } catch (error) {
-            if (statusOwned && error.name === 'AbortError') throw error;
+            if (statusOwned && (error.name === 'AbortError' || error.name === 'TimeoutError')) throw error;
             this.showToast('Error loading sync profiles: ' + error.message, 'error');
         } finally {
             if (showLoading) this.hideLoading();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -447,7 +447,32 @@ class SyncProfileApp {
         }).join('');
     }
 
-    async loadProfiles({ showLoading = true, signal } = {}) {
+    async fetchJsonWithTimeout(url, options = {}) {
+        const controller = new AbortController();
+        const { signal: parentSignal, ...fetchOptions } = options;
+        const abortFromParent = () => controller.abort();
+        if (parentSignal) {
+            if (parentSignal.aborted) controller.abort();
+            else parentSignal.addEventListener('abort', abortFromParent, { once: true });
+        }
+        const timeout = setTimeout(() => controller.abort(), STATUS_LOAD_TIMEOUT_MS);
+
+        try {
+            const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+            const data = await response.json();
+            if (controller.signal.aborted) {
+                const error = new Error('Request timed out');
+                error.name = 'AbortError';
+                throw error;
+            }
+            return { response, data };
+        } finally {
+            clearTimeout(timeout);
+            if (parentSignal) parentSignal.removeEventListener('abort', abortFromParent);
+        }
+    }
+
+    async loadProfiles({ showLoading = true, statusOwned = false } = {}) {
         try {
             if (showLoading) this.showLoading();
             
@@ -458,10 +483,9 @@ class SyncProfileApp {
                 return;
             }
             
-            const response = await fetch('/api/profiles', {
+            const { response, data } = await this.fetchJsonWithTimeout('/api/profiles', {
                 method: 'GET',
                 credentials: 'include', // Include session cookies
-                signal,
                 headers: {
                     'Content-Type': 'application/json'
                 }
@@ -474,8 +498,6 @@ class SyncProfileApp {
                 return;
             }
             
-            const data = await response.json();
-
             if (response.ok && data.success) {
                 this.users = data.data;
                 this.renderProfiles();
@@ -489,7 +511,7 @@ class SyncProfileApp {
                 }
             }
         } catch (error) {
-            if (error.name === 'AbortError') throw error;
+            if (statusOwned && error.name === 'AbortError') throw error;
             this.showToast('Error loading sync profiles: ' + error.message, 'error');
         } finally {
             if (showLoading) this.hideLoading();
@@ -499,12 +521,6 @@ class SyncProfileApp {
     async loadStatuses({ silent = false } = {}) {
         const requestSequence = ++this.statusLoadSequence;
         this.activeStatusRequests += 1;
-        const controller = new AbortController();
-        let timedOut = false;
-        const timeout = setTimeout(() => {
-            timedOut = true;
-            controller.abort();
-        }, STATUS_LOAD_TIMEOUT_MS);
         try {
             if (!silent) {
                 this.activeStatusLoads += 1;
@@ -517,12 +533,12 @@ class SyncProfileApp {
             if (!this.users || this.users.length === 0) {
                 // This status request owns its loading feedback. Avoid letting
                 // the nested profile request hide it before statuses finish.
-                await this.loadProfiles({ showLoading: false, signal: controller.signal });
+                await this.loadProfiles({ showLoading: false, statusOwned: true });
             }
             
             // If no users, render empty status
             if (!this.users || this.users.length === 0) {
-                if (controller.signal.aborted || requestSequence !== this.statusLoadSequence) return;
+                if (requestSequence !== this.statusLoadSequence) return;
                 this.statuses = {};
                 this.renderStatuses();
                 return;
@@ -531,11 +547,10 @@ class SyncProfileApp {
             // Fetch status for each profile
             for (const user of this.users) {
                 try {
-                    const statusResponse = await fetch(`/api/profiles/${user.id}/status`, {
-                        signal: controller.signal
-                    });
+                    const { response: statusResponse, data: statusData } = await this.fetchJsonWithTimeout(
+                        `/api/profiles/${user.id}/status`
+                    );
                     if (statusResponse.ok) {
-                        const statusData = await statusResponse.json();
                         if (statusData.success) {
                             const hasSummary = statusData.data?.last_sync_summary || 
                                             (statusData.data?.books_synced !== undefined && 
@@ -557,13 +572,15 @@ class SyncProfileApp {
                             
                             // Always try to fetch the summary for completed/error states
                             if (statusData.data?.state === 'completed' || statusData.data?.state === 'error') {
-                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses, controller.signal));
+                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses));
                             }
                         }
                     }
                 } catch (error) {
                     console.error(`Error fetching status for profile ${user.id}:`, error);
-                    if (error.name === 'AbortError') throw error;
+                    if (error.name === 'AbortError') {
+                        if (this.statuses[user.id]) statuses[user.id] = this.statuses[user.id];
+                    }
                 }
             }
             
@@ -572,7 +589,7 @@ class SyncProfileApp {
 
             // Only the newest request may publish a status snapshot. A slower
             // response from an older poll must not roll the UI back.
-            if (controller.signal.aborted || requestSequence !== this.statusLoadSequence) return;
+            if (requestSequence !== this.statusLoadSequence) return;
             
             this.statuses = statuses;
             this.renderStatuses();
@@ -580,12 +597,10 @@ class SyncProfileApp {
             
         } catch (error) {
             console.error('Error in loadStatuses:', error);
-            if (!silent && requestSequence === this.statusLoadSequence && (timedOut || error.name !== 'AbortError')) {
+            if (!silent && requestSequence === this.statusLoadSequence && error.name !== 'AbortError') {
                 this.showToast('Error loading statuses: ' + error.message, 'error');
             }
         } finally {
-            clearTimeout(timeout);
-            controller.abort();
             this.activeStatusRequests -= 1;
             if (!silent) {
                 this.activeStatusLoads -= 1;
@@ -594,12 +609,11 @@ class SyncProfileApp {
         }
     }
     
-    async fetchSyncSummary(profileId, statuses, signal) {
+    async fetchSyncSummary(profileId, statuses) {
         try {
             console.log(`Fetching sync summary for profile ${profileId}...`);
-            const response = await fetch(`/api/profiles/${profileId}/summary`, { signal });
+            const { response, data: result } = await this.fetchJsonWithTimeout(`/api/profiles/${profileId}/summary`);
             if (response.ok) {
-                const result = await response.json();
                 console.log('Raw sync summary response:', result);
                 
                 // The API returns the data directly in the response, not in a 'data' property
@@ -2380,7 +2394,6 @@ function closeEditModal() {
 let app;
 document.addEventListener('DOMContentLoaded', () => {
     app = new SyncProfileApp();
-    app.init();
     
     // Add event delegation for read more/less functionality
     document.addEventListener('click', (e) => {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2190,14 +2190,6 @@ class SyncProfileApp {
         } catch (error) {
             console.error('Error starting sync:', error);
             this.showToast(`Error: ${error.message}`, 'error');
-            
-            // Update UI to show error state
-            if (profileId && this.statuses[profileId]) {
-                this.statusLoadSequence += 1;
-                this.statuses[profileId].status = 'error';
-                this.statuses[profileId].error = error.message;
-                this.renderStatuses();
-            }
         } finally {
             this.hideLoading();
         }
@@ -2234,14 +2226,6 @@ class SyncProfileApp {
         } catch (error) {
             console.error('Error cancelling sync:', error);
             this.showToast(`Error: ${error.message}`, 'error');
-            
-            // Update UI to show error state
-            if (profileId && this.statuses[profileId]) {
-                this.statusLoadSequence += 1;
-                this.statuses[profileId].status = 'error';
-                this.statuses[profileId].error = error.message;
-                this.renderStatuses();
-            }
         } finally {
             this.hideLoading();
         }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,5 +1,6 @@
 // Sync Profile Management App
 console.info('Sync UI loaded', { build: '2025-08-16 01:05:44+02:00' });
+const STATUS_LOAD_TIMEOUT_MS = 15000;
 // Global image error handler for cover fallbacks
 window.__absHandleImageError = function(img) {
     try {
@@ -105,11 +106,9 @@ class SyncProfileApp {
             
             // If we get here, either auth is disabled or user is authenticated
             try {
-                // Load data in parallel for better performance
-                await Promise.all([
-                    this.loadProfiles(),
-                    this.loadStatuses()
-                ]);
+                // Status loading owns the initial loading state and loads profiles
+                // before fetching their statuses.
+                await this.loadStatuses();
                 
                 // Start auto-refresh only if we have data to refresh
                 if (this.users.length > 0) {
@@ -448,7 +447,7 @@ class SyncProfileApp {
         }).join('');
     }
 
-    async loadProfiles({ showLoading = true } = {}) {
+    async loadProfiles({ showLoading = true, signal } = {}) {
         try {
             if (showLoading) this.showLoading();
             
@@ -462,6 +461,7 @@ class SyncProfileApp {
             const response = await fetch('/api/profiles', {
                 method: 'GET',
                 credentials: 'include', // Include session cookies
+                signal,
                 headers: {
                     'Content-Type': 'application/json'
                 }
@@ -489,6 +489,7 @@ class SyncProfileApp {
                 }
             }
         } catch (error) {
+            if (error.name === 'AbortError') throw error;
             this.showToast('Error loading sync profiles: ' + error.message, 'error');
         } finally {
             if (showLoading) this.hideLoading();
@@ -498,6 +499,12 @@ class SyncProfileApp {
     async loadStatuses({ silent = false } = {}) {
         const requestSequence = ++this.statusLoadSequence;
         this.activeStatusRequests += 1;
+        const controller = new AbortController();
+        let timedOut = false;
+        const timeout = setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+        }, STATUS_LOAD_TIMEOUT_MS);
         try {
             if (!silent) {
                 this.activeStatusLoads += 1;
@@ -510,12 +517,12 @@ class SyncProfileApp {
             if (!this.users || this.users.length === 0) {
                 // This status request owns its loading feedback. Avoid letting
                 // the nested profile request hide it before statuses finish.
-                await this.loadProfiles({ showLoading: false });
+                await this.loadProfiles({ showLoading: false, signal: controller.signal });
             }
             
             // If no users, render empty status
             if (!this.users || this.users.length === 0) {
-                if (requestSequence !== this.statusLoadSequence) return;
+                if (controller.signal.aborted || requestSequence !== this.statusLoadSequence) return;
                 this.statuses = {};
                 this.renderStatuses();
                 return;
@@ -524,7 +531,9 @@ class SyncProfileApp {
             // Fetch status for each profile
             for (const user of this.users) {
                 try {
-                    const statusResponse = await fetch(`/api/profiles/${user.id}/status`);
+                    const statusResponse = await fetch(`/api/profiles/${user.id}/status`, {
+                        signal: controller.signal
+                    });
                     if (statusResponse.ok) {
                         const statusData = await statusResponse.json();
                         if (statusData.success) {
@@ -548,12 +557,13 @@ class SyncProfileApp {
                             
                             // Always try to fetch the summary for completed/error states
                             if (statusData.data?.state === 'completed' || statusData.data?.state === 'error') {
-                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses));
+                                summaryPromises.push(this.fetchSyncSummary(user.id, statuses, controller.signal));
                             }
                         }
                     }
                 } catch (error) {
                     console.error(`Error fetching status for profile ${user.id}:`, error);
+                    if (error.name === 'AbortError') throw error;
                 }
             }
             
@@ -562,7 +572,7 @@ class SyncProfileApp {
 
             // Only the newest request may publish a status snapshot. A slower
             // response from an older poll must not roll the UI back.
-            if (requestSequence !== this.statusLoadSequence) return;
+            if (controller.signal.aborted || requestSequence !== this.statusLoadSequence) return;
             
             this.statuses = statuses;
             this.renderStatuses();
@@ -570,10 +580,12 @@ class SyncProfileApp {
             
         } catch (error) {
             console.error('Error in loadStatuses:', error);
-            if (!silent && requestSequence === this.statusLoadSequence) {
+            if (!silent && requestSequence === this.statusLoadSequence && (timedOut || error.name !== 'AbortError')) {
                 this.showToast('Error loading statuses: ' + error.message, 'error');
             }
         } finally {
+            clearTimeout(timeout);
+            controller.abort();
             this.activeStatusRequests -= 1;
             if (!silent) {
                 this.activeStatusLoads -= 1;
@@ -582,10 +594,10 @@ class SyncProfileApp {
         }
     }
     
-    async fetchSyncSummary(profileId, statuses) {
+    async fetchSyncSummary(profileId, statuses, signal) {
         try {
             console.log(`Fetching sync summary for profile ${profileId}...`);
-            const response = await fetch(`/api/profiles/${profileId}/summary`);
+            const response = await fetch(`/api/profiles/${profileId}/summary`, { signal });
             if (response.ok) {
                 const result = await response.json();
                 console.log('Raw sync summary response:', result);
@@ -618,6 +630,7 @@ class SyncProfileApp {
             }
         } catch (error) {
             console.error(`Error fetching summary for profile ${profileId}:`, error);
+            if (error.name === 'AbortError') return;
             // Don't show toast here to avoid multiple toasts for multiple failures
         }
     }
@@ -776,7 +789,10 @@ class SyncProfileApp {
                         ? [...card.querySelectorAll('[id]')].find(element => element.id === focusInfo.id)
                         : [...card.querySelectorAll(focusInfo.tagName)].find(element =>
                             element.getAttribute('onclick') === focusInfo.onclick);
-                    if (focusTarget) focusTarget.focus({ preventScroll: true });
+                    const fallbackTarget = card.querySelector(
+                        '.status-actions button[onclick*="startSync"], .status-actions button[onclick*="cancelSync"]'
+                    );
+                    (focusTarget || fallbackTarget)?.focus({ preventScroll: true });
                 }
             }
 
@@ -2152,6 +2168,7 @@ class SyncProfileApp {
                 this.showToast('Sync started successfully', 'success');
                 // Update the specific profile status
                 if (result.data) {
+                    this.statusLoadSequence += 1;
                     this.statuses[profileId] = {
                         ...result.data,
                         profile_id: profileId,
@@ -2171,6 +2188,7 @@ class SyncProfileApp {
             
             // Update UI to show error state
             if (profileId && this.statuses[profileId]) {
+                this.statusLoadSequence += 1;
                 this.statuses[profileId].status = 'error';
                 this.statuses[profileId].error = error.message;
                 this.renderStatuses();
@@ -2203,6 +2221,7 @@ class SyncProfileApp {
                 this.showToast('Sync cancelled', 'info');
                 // Update the specific profile status
                 if (result.data) {
+                    this.statusLoadSequence += 1;
                     this.statuses[profileId] = {
                         ...result.data,
                         profile_id: profileId,
@@ -2223,6 +2242,7 @@ class SyncProfileApp {
             
             // Update UI to show error state
             if (profileId && this.statuses[profileId]) {
+                this.statusLoadSequence += 1;
                 this.statuses[profileId].status = 'error';
                 this.statuses[profileId].error = error.message;
                 this.renderStatuses();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -36,6 +36,7 @@ class SyncProfileApp {
         this.autoRefreshEnabled = true; // Auto-refresh is enabled by default
         this.statusLoadSequence = 0;
         this.activeStatusLoads = 0;
+        this.activeStatusRequests = 0;
         
         this.init();
     }
@@ -496,6 +497,7 @@ class SyncProfileApp {
 
     async loadStatuses({ silent = false } = {}) {
         const requestSequence = ++this.statusLoadSequence;
+        this.activeStatusRequests += 1;
         try {
             if (!silent) {
                 this.activeStatusLoads += 1;
@@ -572,6 +574,7 @@ class SyncProfileApp {
                 this.showToast('Error loading statuses: ' + error.message, 'error');
             }
         } finally {
+            this.activeStatusRequests -= 1;
             if (!silent) {
                 this.activeStatusLoads -= 1;
                 if (this.activeStatusLoads === 0) this.hideLoading();
@@ -2225,6 +2228,7 @@ class SyncProfileApp {
         // Refresh statuses every 5 seconds
         this.refreshInterval = setInterval(() => {
             if (this.autoRefreshEnabled && document.getElementById('sync-tab').classList.contains('active')) {
+                if (this.activeStatusRequests > 0) return;
                 this.loadStatuses({ silent: true });
             }
         }, 5000);

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -718,10 +718,6 @@ class SyncProfileApp {
             `;
     }
 
-    statusSignature(status) {
-        return JSON.stringify(status);
-    }
-
     updateRelativeSyncTime(card, lastSync) {
         const relativeTime = card.querySelector('.relative-sync-time');
         if (!relativeTime || !lastSync) return;
@@ -768,7 +764,7 @@ class SyncProfileApp {
 
         statusArray.forEach(([profileId, status], index) => {
             let card = existingCards.get(profileId);
-            const signature = this.statusSignature(status);
+            const signature = JSON.stringify(status);
             const focusInfo = card && activeElement && card.contains(activeElement)
                 ? { id: activeElement.id, tagName: activeElement.tagName, onclick: activeElement.getAttribute('onclick') }
                 : null;

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -449,16 +449,10 @@ class SyncProfileApp {
 
     async fetchJsonWithTimeout(url, options = {}) {
         const controller = new AbortController();
-        const { signal: parentSignal, ...fetchOptions } = options;
-        const abortFromParent = () => controller.abort();
-        if (parentSignal) {
-            if (parentSignal.aborted) controller.abort();
-            else parentSignal.addEventListener('abort', abortFromParent, { once: true });
-        }
         const timeout = setTimeout(() => controller.abort(), STATUS_LOAD_TIMEOUT_MS);
 
         try {
-            const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+            const response = await fetch(url, { ...options, signal: controller.signal });
             const data = await response.json();
             if (controller.signal.aborted) {
                 const error = new Error('Request timed out');
@@ -468,7 +462,6 @@ class SyncProfileApp {
             return { response, data };
         } finally {
             clearTimeout(timeout);
-            if (parentSignal) parentSignal.removeEventListener('abort', abortFromParent);
         }
     }
 
@@ -727,11 +720,7 @@ class SyncProfileApp {
     }
 
     statusSignature(status) {
-        try {
-            return JSON.stringify(status);
-        } catch (_) {
-            return String(status);
-        }
+        return JSON.stringify(status);
     }
 
     updateRelativeSyncTime(card, lastSync) {
@@ -2182,7 +2171,6 @@ class SyncProfileApp {
                 this.showToast('Sync started successfully', 'success');
                 // The action acknowledgement only contains a message; reload
                 // the authoritative status before updating the card.
-                this.statusLoadSequence += 1;
                 await this.loadStatuses();
             } else {
                 throw new Error(result.error || 'Failed to start sync');
@@ -2218,7 +2206,6 @@ class SyncProfileApp {
                 this.showToast('Sync cancelled', 'info');
                 // The action acknowledgement only contains a message; reload
                 // the authoritative status before updating the card.
-                this.statusLoadSequence += 1;
                 await this.loadStatuses();
             } else {
                 throw new Error(result.error || 'Failed to cancel sync');

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -34,6 +34,8 @@ class SyncProfileApp {
         this.authEnabled = false;
         this.hasRedirectedToLogin = false;
         this.autoRefreshEnabled = true; // Auto-refresh is enabled by default
+        this.statusLoadSequence = 0;
+        this.activeStatusLoads = 0;
         
         this.init();
     }
@@ -445,9 +447,9 @@ class SyncProfileApp {
         }).join('');
     }
 
-    async loadProfiles() {
+    async loadProfiles({ showLoading = true } = {}) {
         try {
-            this.showLoading();
+            if (showLoading) this.showLoading();
             
             // Check authentication status first
             if (this.authEnabled && !this.currentUser) {
@@ -488,23 +490,30 @@ class SyncProfileApp {
         } catch (error) {
             this.showToast('Error loading sync profiles: ' + error.message, 'error');
         } finally {
-            this.hideLoading();
+            if (showLoading) this.hideLoading();
         }
     }
 
-    async loadStatuses() {
+    async loadStatuses({ silent = false } = {}) {
+        const requestSequence = ++this.statusLoadSequence;
         try {
-            this.showLoading();
+            if (!silent) {
+                this.activeStatusLoads += 1;
+                this.showLoading();
+            }
             const statuses = {};
             const summaryPromises = [];
             
             // First, get the list of profiles if not already loaded
             if (!this.users || this.users.length === 0) {
-                await this.loadProfiles();
+                // This status request owns its loading feedback. Avoid letting
+                // the nested profile request hide it before statuses finish.
+                await this.loadProfiles({ showLoading: false });
             }
             
             // If no users, render empty status
             if (!this.users || this.users.length === 0) {
+                if (requestSequence !== this.statusLoadSequence) return;
                 this.statuses = {};
                 this.renderStatuses();
                 return;
@@ -548,6 +557,10 @@ class SyncProfileApp {
             
             // Wait for all summary fetches to complete
             await Promise.all(summaryPromises);
+
+            // Only the newest request may publish a status snapshot. A slower
+            // response from an older poll must not roll the UI back.
+            if (requestSequence !== this.statusLoadSequence) return;
             
             this.statuses = statuses;
             this.renderStatuses();
@@ -555,9 +568,14 @@ class SyncProfileApp {
             
         } catch (error) {
             console.error('Error in loadStatuses:', error);
-            this.showToast('Error loading statuses: ' + error.message, 'error');
+            if (!silent && requestSequence === this.statusLoadSequence) {
+                this.showToast('Error loading statuses: ' + error.message, 'error');
+            }
         } finally {
-            this.hideLoading();
+            if (!silent) {
+                this.activeStatusLoads -= 1;
+                if (this.activeStatusLoads === 0) this.hideLoading();
+            }
         }
     }
     
@@ -591,8 +609,6 @@ class SyncProfileApp {
                     
                     console.log(`Updated sync summary for profile ${profileId}:`, statuses[profileId]);
                     
-                    // Force a re-render of the statuses to show the updated summary
-                    this.statuses = { ...statuses };
                 }
             } else {
                 console.error(`Failed to fetch summary for profile ${profileId}:`, response.status, response.statusText);
@@ -603,27 +619,7 @@ class SyncProfileApp {
         }
     }
     
-    renderStatuses() {
-        const container = document.getElementById('sync-status');
-        if (!container) return;
-
-        if (Object.keys(this.statuses).length === 0) {
-            container.innerHTML = `
-                <div class="text-center" style="grid-column: 1 / -1; padding: 40px;">
-                    <h3>No sync statuses available</h3>
-                    <p>Add a new sync profile and start syncing to see status information.</p>
-                </div>
-            `;
-            return;
-        }
-
-        // Debug: Log status data to console for troubleshooting
-        console.log('Rendering statuses with data:', this.statuses);
-
-        // Convert statuses object to array and filter out any null/undefined entries
-        const statusArray = Object.entries(this.statuses).filter(([_, status]) => status);
-        
-        container.innerHTML = statusArray.map(([profileId, status]) => {
+    renderStatusCard(profileId, status) {
             const progress = status.progress || 0;
             const booksSynced = status.books_synced || 0;
             const booksTotal = status.books_total || 0;
@@ -647,7 +643,7 @@ class SyncProfileApp {
             const profileName = status.profile_name || status.profile_id || 'Unknown Profile';
 
             return `
-                <div class="status-card ${statusState.toLowerCase()}">
+                <div class="status-card ${statusState.toLowerCase()}" data-profile-id="${this.escapeHtml(profileId)}">
                     <div class="status-header">
                         <h3>${this.escapeHtml(profileName)}</h3>
                         <span class="status-badge">${this.escapeHtml(statusText)}</span>
@@ -698,7 +694,98 @@ class SyncProfileApp {
                     </div>
                 </div>
             `;
-        }).join('');
+    }
+
+    statusSignature(status) {
+        try {
+            return JSON.stringify(status);
+        } catch (_) {
+            return String(status);
+        }
+    }
+
+    renderStatuses() {
+        const container = document.getElementById('sync-status');
+        if (!container) return;
+
+        if (Object.keys(this.statuses).length === 0) {
+            if (!container.querySelector('.status-card')) {
+                container.innerHTML = `
+                    <div class="text-center" style="grid-column: 1 / -1; padding: 40px;">
+                        <h3>No sync statuses available</h3>
+                        <p>Add a new sync profile and start syncing to see status information.</p>
+                    </div>
+                `;
+            }
+            return;
+        }
+
+        // Debug: Log status data to console for troubleshooting
+        console.log('Rendering statuses with data:', this.statuses);
+
+        const statusArray = Object.entries(this.statuses).filter(([_, status]) => status);
+        const existingCards = new Map(
+            [...container.querySelectorAll('.status-card[data-profile-id]')]
+                .map(card => [card.dataset.profileId, card])
+        );
+        const retainedProfiles = new Set();
+        const activeElement = document.activeElement;
+        const scrollPosition = { x: window.scrollX, y: window.scrollY };
+        let changed = false;
+
+        // Remove the empty-state message once real status cards are available.
+        [...container.children].filter(child => !child.matches('.status-card')).forEach(child => {
+            child.remove();
+            changed = true;
+        });
+
+        statusArray.forEach(([profileId, status], index) => {
+            let card = existingCards.get(profileId);
+            const signature = this.statusSignature(status);
+            const focusInfo = card && activeElement && card.contains(activeElement)
+                ? { id: activeElement.id, tagName: activeElement.tagName, onclick: activeElement.getAttribute('onclick') }
+                : null;
+
+            if (!card || card.__statusSignature !== signature) {
+                const wrapper = document.createElement('div');
+                wrapper.innerHTML = this.renderStatusCard(profileId, status).trim();
+                const replacement = wrapper.firstElementChild;
+                replacement.__statusSignature = signature;
+                if (card) {
+                    card.replaceWith(replacement);
+                } else {
+                    container.appendChild(replacement);
+                }
+                card = replacement;
+                changed = true;
+
+                if (focusInfo) {
+                    const focusTarget = focusInfo.id
+                        ? [...card.querySelectorAll('[id]')].find(element => element.id === focusInfo.id)
+                        : [...card.querySelectorAll(focusInfo.tagName)].find(element =>
+                            element.getAttribute('onclick') === focusInfo.onclick);
+                    if (focusTarget) focusTarget.focus({ preventScroll: true });
+                }
+            }
+
+            retainedProfiles.add(profileId);
+            const cardAtPosition = container.children[index];
+            if (cardAtPosition !== card) {
+                container.insertBefore(card, cardAtPosition || null);
+                changed = true;
+            }
+        });
+
+        existingCards.forEach((card, profileId) => {
+            if (!retainedProfiles.has(profileId)) {
+                card.remove();
+                changed = true;
+            }
+        });
+
+        if (changed && typeof window.scrollTo === 'function') {
+            window.scrollTo(scrollPosition.x, scrollPosition.y);
+        }
     }
     
     showSyncSummary(profileId) {
@@ -2133,10 +2220,12 @@ class SyncProfileApp {
     }
 
     startAutoRefresh() {
+        if (this.refreshInterval) return;
+
         // Refresh statuses every 5 seconds
         this.refreshInterval = setInterval(() => {
             if (this.autoRefreshEnabled && document.getElementById('sync-tab').classList.contains('active')) {
-                this.loadStatuses();
+                this.loadStatuses({ silent: true });
             }
         }, 5000);
     }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2180,19 +2180,10 @@ class SyncProfileApp {
             
             if (response.ok) {
                 this.showToast('Sync started successfully', 'success');
-                // Update the specific profile status
-                if (result.data) {
-                    this.statusLoadSequence += 1;
-                    this.statuses[profileId] = {
-                        ...result.data,
-                        profile_id: profileId,
-                        profile_name: this.statuses[profileId]?.profile_name || profileId
-                    };
-                    this.renderStatuses();
-                } else {
-                    // If no data in response, refresh all statuses
-                    await this.loadStatuses();
-                }
+                // The action acknowledgement only contains a message; reload
+                // the authoritative status before updating the card.
+                this.statusLoadSequence += 1;
+                await this.loadStatuses();
             } else {
                 throw new Error(result.error || 'Failed to start sync');
             }
@@ -2233,20 +2224,10 @@ class SyncProfileApp {
             
             if (response.ok) {
                 this.showToast('Sync cancelled', 'info');
-                // Update the specific profile status
-                if (result.data) {
-                    this.statusLoadSequence += 1;
-                    this.statuses[profileId] = {
-                        ...result.data,
-                        profile_id: profileId,
-                        profile_name: this.statuses[profileId]?.profile_name || profileId,
-                        status: 'cancelled'
-                    };
-                    this.renderStatuses();
-                } else {
-                    // If no data in response, refresh all statuses
-                    await this.loadStatuses();
-                }
+                // The action acknowledgement only contains a message; reload
+                // the authoritative status before updating the card.
+                this.statusLoadSequence += 1;
+                await this.loadStatuses();
             } else {
                 throw new Error(result.error || 'Failed to cancel sync');
             }


### PR DESCRIPTION
<!-- ⚠️ STOP! READ BEFORE SUBMITTING ⚠️ -->
<!-- Please ensure your PR targets the 'develop' branch. -->
<!-- If this PR targets 'main', it may be closed or redirected automatically. -->

## Summary of Changes

#### Step 1 of 4 to Improve Sync Status UI

Make the five-second Sync Status refresh quiet: background polls leave the loading overlay hidden and update only cards whose status changed. Failed initial profile loads recover automatically with capped backoff, while Start and Cancel request failures remain visible on the affected card without changing the server-reported sync state.

- Prevent overlapping polls and stale responses from replacing a newer status snapshot; bound profile, status, and summary requests so a stalled request does not block later refreshes.
- Keep the last known profile status when a status request fails, label cached cards as last known data until recovery, and redirect to login when a current status request returns 401. Retry an initial profile-load failure from 5 seconds up to a 60-second cap; a valid empty list or authentication redirect ends that retry path.
- Reload authoritative status after Start or Cancel; show request failures as dismissible per-card action errors rather than fabricated sync errors.
- Preserve unchanged status cards and update relative timestamps during polling. Use delegated profile actions and escape profile identifiers in HTML attributes.
- Document the UI's browser minimums in the README and guard status loading when `AbortController` is unavailable.

## Testing Instructions

- `node --check web/static/app.js` and diff checks passed.
- Temporary, uncommitted JavaScript checks covered stalled and failed requests, silent recovery, empty profiles, authentication redirects, non-overlapping polls, the missing-`AbortController` path, per-card action errors, retry backoff/reset, cached-card unavailable/recovery, and relative-time rendering.
- `make test` and `make build` passed during the original local validation. Later changes are confined to the web UI and documentation; the current PR head's Test, Go 1.26, and scan checks passed on CI.

## Multi-Step Project

1. **Quiet background refresh (this PR):** Keep timer-driven polls silent and bounded, reject stale results, retain unchanged cards, recover from temporary profile-load failures, and show action failures on the relevant card.
2. **Per-run outcomes and live status API:** Give every attempted book one outcome, reconcile category counts to processed, classify technical failures separately, and publish immediate per-profile mismatch and missing-book results. Keep legacy fields usable while the UI moves to the new contract.
3. **Sync Status and View Details redesign:** Consume the outcome contract, remove the duplicate `Books Synced` and misleading all-found text, show the full category breakdown, and refresh open details smoothly. Preserve scroll and focus; when a card is replaced, move focus to Start/Cancel only if that was the previously focused action.
4. **Run lifecycle and report history:** Add phase/activity state, truthful canceled/failed partial reports, distinct last-attempted and last-successful timestamps, and a bounded persisted final report.

[Full Plan Document](https://github.com/Snuffy2/audiobookshelf-hardcover-sync/blob/plan/sync-status-improvements/docs/sync-status-improvement-plan.md)

## Checklist

- [x] Tests pass locally
- [x] Tests pass on CI
- [x] Code quality checks pass on CI
- [x] Documentation is updated
- [x] Changelog is updated